### PR TITLE
temporarily hide broken links; remove query browser and web manager

### DIFF
--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -2,7 +2,9 @@
 System Parameters
 *****************
 
-This chapter provides information about configuring system parameters that can affect the system performance. System parameters determine overall performance and operation of the system. This chapter explains how to use configuration files for database server and broker as well as a description of each parameter. For CUBRID Manager server configuration, see `CUBRID Manager Manual <http://www.cubrid.org/wiki_tools/entry/cubrid-manager-manual>`_.
+This chapter provides information about configuring system parameters that can affect the system performance. System parameters determine overall performance and operation of the system. This chapter explains how to use configuration files for database server and broker as well as a description of each parameter. 
+
+.. FIXME: For CUBRID Manager server configuration, see `CUBRID Manager Manual <http://www.cubrid.org/wiki_tools/entry/cubrid-manager-manual>`_.
 
 This chapter covers the following topics:
 

--- a/en/admin/control.rst
+++ b/en/admin/control.rst
@@ -1747,14 +1747,6 @@ This page describes parameters that are specified in the **cm.conf** file.
 
     **server_long_query_time** is a parameter used to configure delay reference time in seconds when configuring **slow_query** which is one of server diagnostics items. The default value is **10** . If the execution time of the query performed on the server exceeds this parameter value, the number of the **slow_query** parameters will increase.
 
-**support_web_manager**
-
-    **support_web_manager** is a parameter used to configure starting CUBRID Web Manager or not. The default value is NO.
- 
-**web_manager_path**
-
-    **web_manager_path** is a parameter used to configure a path of CUBRID Web Manager. The default value is {CUBRID installed path}/share/webmanager.
- 
 **auto_job_timeout**
 
     **auto_job_timeout** is a parameter used to configure timeout of auto job for cub_auto. The default value is 43200 (12 hour).

--- a/en/api/adodotnet.rst
+++ b/en/api/adodotnet.rst
@@ -4,7 +4,7 @@ ADO.NET Driver
 
 ADO.NET is a set of classes that expose data access services to the .NET programmer. ADO.NET provides a rich set of components for creating distributed, data-sharing applications. It is an integral part of the .NET Framework, providing access to relational, XML, and application data. ADO.NET supports a variety of development needs, including the creation of front-end database clients and middle-tier business objects used by applications, tools, languages, or Internet browsers.
 
-To download ADO.NET driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-ado-net-driver\.
+.. FIXME: To download ADO.NET driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-ado-net-driver\.
 
 Installing and Configuring ADO.NET
 ==================================
@@ -488,15 +488,15 @@ The following list displays the error code and messages shown up when using CUBR
 | 23             | ER_UNKNOWN             | "Error"                                                               |
 +----------------+------------------------+-----------------------------------------------------------------------+
 
-NHibernate
-----------
+.. FIXME: NHibernate
+.. FIXME: ----------
 
-CUBRID will be accessed from NHibernate using CUBRID ADO.NET Data Provider. For more information, see http://www.cubrid.org/wiki_apis/entry/cubrid-nhibernate-support.
+.. FIXME: CUBRID will be accessed from NHibernate using CUBRID ADO.NET Data Provider. For more information, see http://www.cubrid.org/wiki_apis/entry/cubrid-nhibernate-support.
 
-Java Stored Procedure
----------------------
+.. FIXME: Java Stored Procedure
+.. FIXME: ---------------------
 
-For how to call Java stored procedure in .NET, see http://www.cubrid.org/wiki_apis/entry/how-to-calling-java-stored-functionprocedurec.
+.. FIXME: For how to call Java stored procedure in .NET, see http://www.cubrid.org/wiki_apis/entry/how-to-calling-java-stored-functionprocedurec.
 
 ADO.NET API
 ===========

--- a/en/api/cci.rst
+++ b/en/api/cci.rst
@@ -21,7 +21,7 @@ Because CUBRID CCI driver is connected through the CUBRID broker, you can manage
 
 .. image:: /images/image54.jpg
 
-To download CCI driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-cci-driver .
+.. FIXME: To download CCI driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-cci-driver .
 
 CCI Programming
 ===============

--- a/en/api/index.rst
+++ b/en/api/index.rst
@@ -19,5 +19,5 @@ This chapter covers the following API:
     ruby.rst
     node_js.rst
     
-If you want to get the latest information about CUBRID-supported drivers, see `http://www.cubrid.org/wiki_apis/entry/cubrid-apis-wiki <http://www.cubrid.org/wiki_apis/entry/cubrid-apis-wiki>`_.
+.. FIXME: If you want to get the latest information about CUBRID-supported drivers, see `http://www.cubrid.org/wiki_apis/entry/cubrid-apis-wiki <http://www.cubrid.org/wiki_apis/entry/cubrid-apis-wiki>`_.
 

--- a/en/api/jdbc.rst
+++ b/en/api/jdbc.rst
@@ -9,7 +9,7 @@ JDBC Overview
 
 CUBRID JDBC driver (**cubrid_jdbc.jar**) implements an interface to enable access from applications in Java to CUBRID database server. CUBRID JDBC driver is installed in the <*directory where CUBRID is installed*>/**jdbc** directory. The driver has been developed based on the JDBC 2.0 specification and the default driver provided is complied with JDK 1.6.
 
-To download JDBC driver or get the latest information, please visit http://www.cubrid.org/wiki_apis/entry/cubrid-jdbc-driver\ .
+.. FIXME: To download JDBC driver or get the latest information, please visit http://www.cubrid.org/wiki_apis/entry/cubrid-jdbc-driver\ .
 
 **Verifying CUBRID JDBC Driver Version**
 

--- a/en/api/node_js.rst
+++ b/en/api/node_js.rst
@@ -16,7 +16,7 @@ For more details, see http://nodejs.org/.
 
 If you want to download CUBRRID Node.js driver or find the recent information, see the following sites:
 
-*   Introducing project: http://www.cubrid.org/wiki_apis/entry/cubrid-node-js-driver
+.. FIXME: *   Introducing project: http://www.cubrid.org/wiki_apis/entry/cubrid-node-js-driver
 *   source code main repository: https://github.com/CUBRID/node-cubrid
 
 Installing Node.js 
@@ -40,16 +40,17 @@ If you uninstall CUBRID Node.js driver, do the following command. ::
 CUBRID Node.js Programming
 ==========================
 
-Connection
-----------
+.. FIXME: Connection
+.. FIXME: ----------
 
-* `Connecting to CUBRID through Node.js Driver <http://www.cubrid.org/wiki_apis/entry/connecting-to-cubrid-through-node-js-driver>`_
+.. FIXME: * `Connecting to CUBRID through Node.js Driver <http://www.cubrid.org/wiki_apis/entry/connecting-to-cubrid-through-node-js-driver>`_
 
 Examples
 --------
 
-* `Common uses of CUBRID Node.js API with examples <http://www.cubrid.org/blog/cubrid-appstools/common-uses-of-cubrid-nodejs-api-with-examples/>`_
-* `Executing Queries with CUBRID Node.js Driver <http://www.cubrid.org/wiki_apis/entry/executing-queries-with-cubrid-node-js-driver>`_
+.. FIXME: The following blog is missing
+.. FIXME: * `Common uses of CUBRID Node.js API with examples <http://www.cubrid.org/blog/cubrid-appstools/common-uses-of-cubrid-nodejs-api-with-examples/>`_
+.. FIXME: * `Executing Queries with CUBRID Node.js Driver <http://www.cubrid.org/wiki_apis/entry/executing-queries-with-cubrid-node-js-driver>`_
 * `Example using events <https://github.com/CUBRID/node-cubrid#usage>`_
 * `Example based on asyc Node.js module <https://github.com/CUBRID/node-cubrid#usage>`_
 * `Example plain callback style <https://github.com/CUBRID/node-cubrid#usage>`_

--- a/en/api/odbc.rst
+++ b/en/api/odbc.rst
@@ -8,7 +8,7 @@ CUBRID ODBC driver is written based on CCI API, but it's not affected by :ref:`C
 
 .. note:: ODBC is not affected by CCI_DEFAULT_AUTOCOMMIT is from 9.3 version. In the previous versions, you should set CCI_DEFAULT_AUTOCOMMIT as OFF.
 
-To download ODBC driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-odbc-driver.
+.. FIXME: To download ODBC driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-odbc-driver.
 
 **Data Type Mapping Between CUBRID and ODBC**
 

--- a/en/api/oledb.rst
+++ b/en/api/oledb.rst
@@ -8,12 +8,14 @@ OLE DB (Object Linking and Embedding, Database) is an API designed by Microsoft 
 
 CUBRID OLE DB driver is written based on CCI API so affected by CCI configurations such as **CCI_DEFAULT_AUTOCOMMIT**.
 
-To download OLD DB driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-oledb-driver .
+.. FIXME: To download OLD DB driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-oledb-driver .
 
 .. note::
 
     *   If your CUBRID OLEDB driver version is 9.1.0.p1 or later, only one installation package is needed for both Windows 32 bit and 64 bit. Our new OLEDB installer supports CUBRID DB engine 8.4.1 or later.
-    *   If your CUBRID OLEDB Driver version is 9.1.0 or older, it may have a problem on 64 bit operating system. Please see our installation tutorial for an old version: http://www.cubrid.org/wiki_apis/entry/cubrid-oledb-driver-installation-instructions-old
+    *   If your CUBRID OLEDB Driver version is 9.1.0 or older, it may have a problem on 64 bit operating system. 
+
+.. FIXME: Please see our installation tutorial for an old version: http://www.cubrid.org/wiki_apis/entry/cubrid-oledb-driver-installation-instructions-old
 
 Installing and Configuring OLE DB
 =================================
@@ -33,9 +35,11 @@ Before you start developing applications with CUBRID, you will need the Provider
         *   README.txt
         *   uninstall.exe    
 
-*   **Building from source code**: If you want to change CUBRID OLED DB Data Provider Installer, you can build it for yourself by compiling the source code. For details, see below:
+*   **Building from source code**: If you want to change CUBRID OLED DB Data Provider Installer, you can build it for yourself by compiling the source code. 
 
-    http://www.cubrid.org/wiki_apis/entry/compiling-the-cubrid-ole-db-installer 
+.. FIXME: For details, see below:
+
+.. FIXME:    http://www.cubrid.org/wiki_apis/entry/compiling-the-cubrid-ole-db-installer 
 
     If you do not use the CUBRID OLED DB Provider installer, you should execute the command below to register the driver. The version of the driver should match the version of your operating system. For 32 bit, the **regsvr32** command should be executed in the **C:\Windows\system32** directory; for 64 bit, the **regsvr32** command should be executed in the **C:\Windows\SysWOW64** directory. ::
 

--- a/en/api/pdo.rst
+++ b/en/api/pdo.rst
@@ -15,7 +15,7 @@ In particular, having a CUBRID PDO driver means that any application that uses P
 
 CUBRID PDO driver is based on CCI API so affected by CCI configurations such as **CCI_DEFAULT_AUTOCOMMIT**.
 
-To download PDO driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-pdo-driver .
+.. FIXME: To download PDO driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-pdo-driver .
 
 Installing and Configuring PDO
 ==============================
@@ -31,7 +31,9 @@ Linux
 
 **Installing CUBRID PHP Driver using PECL**
 
-If **PECL** package has been installed on your system, the installation of CUBRID PDO driver is straightforward. **PECL** will download and compile the driver for you. If you do not have **PECL** installed, follow the instructions at http://www.cubrid.org/wiki_apis/entry/installing-cubrid-php-driver-using-pecl to get it installed.
+If **PECL** package has been installed on your system, the installation of CUBRID PDO driver is straightforward. **PECL** will download and compile the driver for you. 
+
+.. FIXME: If you do not have **PECL** installed, follow the instructions at http://www.cubrid.org/wiki_apis/entry/installing-cubrid-php-driver-using-pecl to get it installed.
 
 #.  Enter the following command to install the latest version of CUBRID PDO driver. ::
     

--- a/en/api/perl.rst
+++ b/en/api/perl.rst
@@ -6,7 +6,7 @@ Perl Driver
 
 CUBRID Perl driver is written based on CCI API so affected by CCI configurations such as **CCI_DEFAULT_AUTOCOMMIT**.
 
-To download Perl driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-perl-driver . 
+.. FIXME: To download Perl driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-perl-driver . 
 
 .. note::
 

--- a/en/api/php.rst
+++ b/en/api/php.rst
@@ -8,12 +8,14 @@ The official one is available as a PECL package. PECL is a repository for PHP ex
 
 CUBRID PHP driver is written based on CCI API so affected by CCI configurations such as **CCI_DEFAULT_AUTOCOMMIT**.
 
-To download PHP driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-php-driver .
+.. FIXME: To download PHP driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-php-driver .
 
 Installing and Configuring PHP
 ==============================
 
-The easiest and fastest way to get all applications installed on your system is to install CUBRID, Apache web server, PHP, and CUBRID PHP driver at the same time. For details, see http://www.cubrid.org/wiki_apis/entry/install-cubrid-with-apache-and-php-on-ubuntu .
+The easiest and fastest way to get all applications installed on your system is to install CUBRID, Apache web server, PHP, and CUBRID PHP driver at the same time. 
+
+.. FIXME: For details, see http://www.cubrid.org/wiki_apis/entry/install-cubrid-with-apache-and-php-on-ubuntu .
 
 For Linux
 ---------
@@ -27,7 +29,8 @@ For Linux
 **Installing CUBRID PHP Driver using PECL**
 
 If **PECL** package has been installed on your system, the installation of CUBRID PHP driver is straightforward. **PECL** will download and compile the driver for you. 
-If you do not have **PECL** installed, follow the instructions at http://www.cubrid.org/wiki_apis/entry/installing-cubrid-php-driver-using-pecl to get it installed.
+
+.. FIXME: If you do not have **PECL** installed, follow the instructions at http://www.cubrid.org/wiki_apis/entry/installing-cubrid-php-driver-using-pecl to get it installed.
 
 #.  Enter the following command to install the latest version of CUBRID PHP driver.
 

--- a/en/api/python.rst
+++ b/en/api/python.rst
@@ -6,7 +6,7 @@ Python Driver
 
 CUBRID Python driver is written based on CCI API so affected by CCI configurations such as **CCI_DEFAULT_AUTOCOMMIT**.
 
-If you want to download Python driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-python-driver .
+.. FIXME: If you want to download Python driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-python-driver .
 
 Installing and Configuring Python
 =================================
@@ -40,7 +40,9 @@ There are three ways to install CUBRID Python driver on Linux, UNIX, and UNIX-li
 
 **Building CUBRID Python Driver from Source Code (Linux)**
 
-To install CUBRID Python driver by compiling source code, you should have Python Development Package installed on your system. If you do not have the package, follow the instructions stated at http://www.cubrid.org/wiki_apis/entry/install-python-development-package .
+To install CUBRID Python driver by compiling source code, you should have Python Development Package installed on your system. 
+
+.. FIXME: If you do not have the package, follow the instructions stated at http://www.cubrid.org/wiki_apis/entry/install-python-development-package .
 
 #.  Download the source code from http://www.cubrid.org/?mid=downloads&item=python_driver.
 

--- a/en/api/ruby.rst
+++ b/en/api/ruby.rst
@@ -6,7 +6,7 @@ CUBRID Ruby driver implements the interface to enable access from applications i
 
 CUBRID Ruby driver is written based on CCI API so affected by CCI configurations such as **CCI_DEFAULT_AUTOCOMMIT**.
 
-To download Ruby driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-ruby-driver.
+.. FIXME: To download Ruby driver or get the latest information, click http://www.cubrid.org/wiki_apis/entry/cubrid-ruby-driver.
 
 Installing and Configuring Ruby
 ===============================
@@ -29,9 +29,9 @@ Enter the command line below to install the latest version of CUBRID Ruby driver
 
     gem install cubrid
 
-.. note:: 
+.. FIXME: .. note:: 
 
-    If you do not have RubyInstaller, see http://www.cubrid.org/wiki_apis/entry/cubrid-ruby-driver-installation-instructions .
+.. FIXME:     If you do not have RubyInstaller, see http://www.cubrid.org/wiki_apis/entry/cubrid-ruby-driver-installation-instructions .
 
 Ruby Sample Program
 ===================

--- a/en/csql.rst
+++ b/en/csql.rst
@@ -2,7 +2,7 @@
 CSQL Interpreter
 ****************
 
-To execute SQL statements in CUBRID, you need to use either a Graphical User Interface(GUI)-based `CUBRID Query Browser <http://www.cubrid.org/wiki_tools/entry/cubrid-query-browser>`_ or a console-based CSQL Interpreter.
+To execute SQL statements in CUBRID, you need to use either a Graphical User Interface(GUI)-based CUBRID Manager or a console-based CSQL Interpreter.
 
 CSQL is an application that allows users to use SQL statements through a command-driven interface. This section briefly explains how to use the CSQL Interpreter and associated commands.
 

--- a/en/env.rst
+++ b/en/env.rst
@@ -14,7 +14,7 @@ CUBRID Environment Variables
 
 .. note:: 
 
-    *   A user of CUBRID Manager or CUBRID Query Browser should specify **CUBRID_MSG_LANG**, an environment variable of DB server node into **en_US** to print out messages normally after running database related features. However, database related features are run normally and just the output messages are broken when **CUBRID_MSG_LANG** is not **en_US**.
+    *   A user of CUBRID Manager should specify **CUBRID_MSG_LANG**, an environment variable of DB server node into **en_US** to print out messages normally after running database related features. However, database related features are run normally and just the output messages are broken when **CUBRID_MSG_LANG** is not **en_US**.
     *   To apply the changed **CUBRID_MSG_LANG**, CUBRID system of DB server node should be restarted(cubrid service stop, cubrid service start).
 
 *   **CUBRID_TMP**: The environment variable that specifies the location where the cub_master process and the cub_broker process store the UNIX domain socket file in CUBRID for Linux. If it is not specified, the cub_master process stores the UNIX domain socket file under the **/tmp** directory and the cub_broker process stores the UNIX domain socket file under the **$CUBRID/var/CUBRID_SOCK** directory (not used in CUBRID for Windows).
@@ -202,9 +202,6 @@ If you use CUBRID for Windows at the broker machine or the DB server machine, al
 +---------------+---------------+---------------+----------------+-----------------------------------------------------+--------------------------+------------------------+
 | Manager use   | Manager       | application   | 8001           | 8001                                                | Open                     |                        |
 |               | server        |               |                |                                                     |                          |                        |
-+---------------+---------------+               |                |                                                     |                          |                        |
-| Web Manager   | Web Manager   |               |                |                                                     |                          |                        |
-| use           | server        |               |                |                                                     |                          |                        |
 +---------------+---------------+---------------+----------------+-----------------------------------------------------+--------------------------+------------------------+
 
 (*): The machine which has the CAS, CSQL, copylogdb, or applylogdb process
@@ -365,17 +362,15 @@ On the master node, the applylogdb and the copylogdb run for the case that the m
 
 .. _cwm-cm-ports:
 
-Ports for CUBRID Web Manager and CUBRID Manager Server
-------------------------------------------------------
+Ports for CUBRID Manager Server
+-------------------------------
 
-The following table summarizes the ports, based on the listening processes, used for the CUBRID Web Manager and the CUBRID Manager server. The ports are identical regardless of the OS type.
+The following table summarizes the ports, based on the listening processes, used for CUBRID Manager server. The ports are identical regardless of the OS type.
 
 +--------------------------+--------------+----------------+--------------------------+
 | Listener                 | Requester    | Port           | Firewall Port Setting    |
 +==========================+==============+================+==========================+
-| Manager server,          | application  | 8001           | Open                     |
-| Web Manager server       |              |                |                          |
+| Manager server           | application  | 8001           | Open                     |
 +--------------------------+--------------+----------------+--------------------------+
 
 *   The port used when the CUBRID Manager client accesses the CUBRID Manager server process is **cm_port** of the cm.conf. The default value is 8001.
-*   The port used when the CUBRID Web Manager client accesses the CUBRID Web Manager server process is also **cm_port** of the cm.conf.

--- a/en/install.rst
+++ b/en/install.rst
@@ -20,7 +20,7 @@ The platforms supported by CUBRID and hardware/software requirements for the ins
 
 Beginning with 2008 R4.0, CUBRID Manager Client is not automatically installed when installing the CUBRID package. For this reason, if you require CUBRID Manager you must install it separately. The CUBRID can be downloaded from http://ftp.cubrid.org.
 
-Including CUBRID Query Browser, a variety of drivers such as PHP, ODBC and OLE DB can also be downloaded from http://ftp.cubrid.org.
+A variety of drivers such as PHP, ODBC and OLE DB can also be downloaded from http://ftp.cubrid.org.
 
 For more information on the CUBRID engine, tools, and drivers, see http://www.cubrid.org.
 
@@ -196,15 +196,17 @@ You can modify the environment such as service ports etc. edit the parameters of
 
 **Installing CUBRID Interfaces**
 
-You can see the latest information on interface modules such as CCI, JDBC, PHP, ODBC, OLE DB, ADO.NET, Ruby, Python and Node.js and install them by downloading files from http://www.cubrid.org/wiki_apis.
+You can download interface modules such as CCI, JDBC, PHP, ODBC, OLE DB, ADO.NET, Ruby, Python and Node.js from http://www.cubrid.org/downloads.
+
+.. FIXME You can see the latest information on interface modules such as CCI, JDBC, PHP, ODBC, OLE DB, ADO.NET, Ruby, Python and Node.js and install them by downloading files from http://www.cubrid.org/downloads.
 
 A simple description on each driver can be found on :doc:`/api/index`.
 
 **Installing CUBRID Tools**
 
-You can see the latest information on tools such as CUBRID Manager and CUBRID Query Browser and install them by downloading files from http://www.cubrid.org/wiki_tools.
+You can download various tools including CUBRID Manager and CUBRID Migration Toolkit from http://www.cubrid.org/downloads.
 
-CUBRID Web Manager is also installed when the CUBRID is installed. For more details, see `CUBRID Web Manager Manual <http://www.cubrid.org/wiki_tools/entry/cubrid-web-manager-manual>`_.
+.. FIXME You can see the latest information on tools such as CUBRID Manager and install them by downloading files from http://www.cubrid.org/downloads.
 
 .. _Installing-and-Running-on-Windows:
 
@@ -256,14 +258,9 @@ You can change configuration such as service ports to meet the user environment 
 
 *   **cm.conf**
     
-    A configuration file for CUBRID Manager. The port that the Manager server process uses is called  **cm_port** and its default value is **8001**. For details, see `CUBRID Manager Manual <http://www.cubrid.org/wiki_tools/entry/cubrid-manager-manual>`_. 
+    A configuration file for CUBRID Manager. The port that the Manager server process uses is called  **cm_port** and its default value is **8001**. 
 
-    To start CUBRID Web Manager, firstly you should set the value of **support_web_manager** parameter as "YES", then restart CUBRID Manager Server. To use CUBRID Web Manager, access "https://localhost:8001".
-
-    ::
-    
-        $ cubrid manager stop
-        $ cubrid manager start
+    .. FIXME: For details, see `CUBRID Manager Manual <http://www.cubrid.org/wiki_tools/entry/cubrid-manager-manual>`_. 
 
 *   **cubrid.conf**
     
@@ -279,15 +276,17 @@ You can change configuration such as service ports to meet the user environment 
 
 **Installing CUBRID Interfaces**
 
-You can see the latest information on interface modules such as JDBC, PHP, ODBC, and OLE DB and install them by downloading files from `<http://www.cubrid.org/wiki_apis>`_.
+You can download interface modules such as CCI, JDBC, PHP, ODBC, OLE DB, ADO.NET, Ruby, Python and Node.js from http://www.cubrid.org/downloads.
+
+.. FIXME: You can see the latest information on interface modules such as JDBC, PHP, ODBC, and OLE DB and install them by downloading files from `<http://www.cubrid.org/wiki_apis>`_.
 
 A simple description on each driver can be found on :doc:`/api/index`.
 
 **Installing CUBRID Tools**
 
-You can see the latest information on tools such as CUBRID Manager and CUBRID Query Browser and install them by downloading files from `<http://www.cubrid.org/wiki_tools>`_.
+You can download various tools including CUBRID Manager and CUBRID Migration Toolkit from http://www.cubrid.org/downloads.
 
-CUBRID Web Manager is installed when CUBRID is installed. For more details, see `CUBRID Web Manager Manual <http://www.cubrid.org/wiki_tools/entry/cubrid-web-manager-manual>`_ .
+.. FIXME: You can see the latest information on tools such as CUBRID Manager and install them by downloading files from `<http://www.cubrid.org/wiki_tools>`_.
 
 Installing with a Compressed Package
 ------------------------------------

--- a/en/intro.rst
+++ b/en/intro.rst
@@ -23,11 +23,9 @@ CUBRID is an object-relational database management system (DBMS) consisting of t
 
 *   The broker is a CUBRID-specific middleware that relays the communication between the database server and external applications. It provides functions including connection pooling, monitoring, and log tracing and analysis.
 
-*   The CUBRID Manager is a GUI tool that allows users to remotely manage the database and the broker. It also provides the Query Editor, a convenient tool that allows users to execute SQL queries on the database server. For more information about CUBRID Manager, see http://www.cubrid.org/wiki_tools/entry/cubrid-manager.
+*   The CUBRID Manager is a GUI tool that allows users to remotely manage the database and the broker. It also provides the Query Editor, a convenient tool that allows users to execute SQL queries on the database server. 
 
-.. note::
-
-    CUBRID Query Browser is a light version of CUBRID Manager and provides only the features which application developers require: the database management and query editor features. For more details on CUBRID Query Browser, see http://www.cubrid.org/wiki_tools/entry/cubrid-query-browser .
+.. FIXME: For more information about CUBRID Manager, see http://www.cubrid.org/wiki_tools/entry/cubrid-manager.
 
 .. image:: /images/image1.png
 
@@ -192,7 +190,7 @@ CUBRID provides various Application Programming Interfaces (APIs). The following
 
 All interface modules access the database server through the broker. The broker is a middleware that allows various application clients to connect to the database server. When it receives a request from an interface module, it calls a native C API provided by the database server's client library.
 
-You can find the latest information on interface modules; visit the Web site at http://www.cubrid.org/wiki_apis\.
+.. FIXME: You can find the latest information on interface modules; visit the Web site at http://www.cubrid.org/wiki_apis\.
 
 CUBRID Characteristics
 ======================

--- a/en/qrytool.rst
+++ b/en/qrytool.rst
@@ -6,7 +6,7 @@ CSQL Interpreter
 
 The CSQL Interpreter is a program used to execute the SQL statements and retrieve results in a way that CUBRID supports. The entered SQL statements and the results can be stored as a file. For more information, see :ref:`csql-intro` and :ref:`csql-exec-mode`.
 
-CUBRID also provides a GUI-based program called "CUBRID Manager" or "CUBRID Query Browser." By using these tools, you can execute all SQL statements and retrieve results in the query editor of CUBRID Manager. For more information, see :ref:`cm-cqb`.
+CUBRID also provides a GUI-based program called "CUBRID Manager". You can execute all SQL statements and retrieve results in the query editor of CUBRID Manager. For more information, see :ref:`cm-cqb`.
 
 This section describes how to use the CSQL Interpreter on the Linux environment
 
@@ -95,85 +95,61 @@ After the CSQL has been executed, you can enter the SQL into the CSQL prompt. Ea
 Management Tools
 ================
 
-+--------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------+---------------------------------------------------------------------+
-|                          | Summary of features                                                         | Downloads of the recent files                                   | Links to the latest documents                                       |
-+==========================+=============================================================================+=================================================================+=====================================================================+
-| CUBRID Web Manager       | Web based tool for SQL execution and DB operation.                          | `CUBRID Web Manager Download                                    | `CUBRID Web Manager Documents                                       | 
-|                          |                                                                             | <http://ftp.cubrid.org/CUBRID_Tools/CUBRID_Web_Manager>`_       | <http://www.cubrid.org/wiki_tools/entry/cubrid-web-manager>`_       |   
-|                          | 1) Possible to access to DB with a web browser                              |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |   
-|                          | 2) Possible to use instantly after installing CUBRID                        |                                                                 |                                                                     |
-|                          |    (CUBRID 2008 R4.3 or higher)                                             |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |   
-|                          | 3) Useful to manage a single host                                           |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |   
-|                          | 4) DB access via CUBRID Manager server                                      |                                                                 |                                                                     |
-+--------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------+---------------------------------------------------------------------+
-| CUBRID Manager           | Java client tool for SQL execution & DB operation.                          | `CUBRID Manager Download                                        | `CUBRID Manager Documents                                           |
-|                          |                                                                             | <http://ftp.cubrid.org/CUBRID_Tools/CUBRID_Manager>`_           | <http://www.cubrid.org/wiki_tools/entry/cubrid-manager>`_           |   
-|                          | 1) Java-based management tool (JRE 1.6 or higher required)                  |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |   
-|                          | 2) Auto upgrade after the initial download                                  |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |   
-|                          | 3) Useful to manage multiple hosts                                          |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |   
-|                          | 4) DB access via CUBRID Manager server                                      |                                                                 |                                                                     |
-+--------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------+---------------------------------------------------------------------+
-| CUBRID Query Browser     | Java client tool for SQL execution only.                                    | `CUBRID Query Browser Download                                  | `CUBRID Query Browser Documents                                     |
-|                          |                                                                             | <http://ftp.cubrid.org/CUBRID_Tools/CUBRID_Query_Browser>`_     | <http://www.cubrid.org/wiki_tools/entry/cubrid-query-browser>`_     |  
-|                          | 1) Java-based management tool (JRE 1.6 or higher required)                  |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |  
-|                          | 2) Auto upgrade after the initial download                                  |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |  
-|                          | 3) Useful to manage multiple hosts                                          |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |  
-|                          | 4) Direct DB access via JDBC                                                |                                                                 |                                                                     |
-+--------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------+---------------------------------------------------------------------+
-| CUBRID Migration Toolkit | Java-based client tool to migrate schema and data from source DB            | `CUBRID Migration Toolkit Download                              | `CUBRID Migration Toolkit Documents                                 |
-|                          | (MySQL, Oracle, CUBRID) to CUBRID.                                          | <http://ftp.cubrid.org/CUBRID_Tools/CUBRID_Migration_Toolkit>`_ | <http://www.cubrid.org/wiki_tools/entry/cubrid-migration-toolkit>`_ |
-|                          |                                                                             |                                                                 |                                                                     |   
-|                          | 1) Java-based management tool (JRE 1.6 or higher required)                  |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |   
-|                          | 2) Auto upgrade after the initial download                                  |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |   
-|                          | 3) Available migration only for multiple queries results,                   |                                                                 |                                                                     |
-|                          |    the reuse of migration scenario; good to batch job                       |                                                                 |                                                                     |
-|                          |                                                                             |                                                                 |                                                                     |   
-|                          | 4) Direct DB access with JDBC                                               |                                                                 |                                                                     |
-+--------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------+---------------------------------------------------------------------+
++--------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------+
+|                          | Summary of features                                                         | Downloads of the recent files                                   |
++==========================+=============================================================================+=================================================================+
+| CUBRID Manager           | Java client tool for SQL execution & DB operation.                          | `CUBRID Manager Download                                        |
+|                          |                                                                             | <http://ftp.cubrid.org/CUBRID_Tools/CUBRID_Manager>`_           |
+|                          | 1) Java-based management tool (JRE 1.6 or higher required)                  |                                                                 |
+|                          |                                                                             |                                                                 |
+|                          | 2) Auto upgrade after the initial download                                  |                                                                 |
+|                          |                                                                             |                                                                 |
+|                          | 3) Useful to manage multiple hosts                                          |                                                                 |
+|                          |                                                                             |                                                                 |
+|                          | 4) DB access via CUBRID Manager server                                      |                                                                 |
++--------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------+
+| CUBRID Migration Toolkit | Java-based client tool to migrate schema and data from source DB            | `CUBRID Migration Toolkit Download                              |
+|                          | (MySQL, Oracle, CUBRID) to CUBRID.                                          | <http://ftp.cubrid.org/CUBRID_Tools/CUBRID_Migration_Toolkit>`_ |
+|                          |                                                                             |                                                                 |
+|                          | 1) Java-based management tool (JRE 1.6 or higher required)                  |                                                                 |
+|                          |                                                                             |                                                                 |
+|                          | 2) Auto upgrade after the initial download                                  |                                                                 |
+|                          |                                                                             |                                                                 |
+|                          | 3) Available migration only for multiple queries results,                   |                                                                 |
+|                          |    the reuse of migration scenario; good to batch job                       |                                                                 |
+|                          |                                                                             |                                                                 |
+|                          | 4) Direct DB access with JDBC                                               |                                                                 |
++--------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------+
 
-Running SQL with CUBRID Web Manager
------------------------------------
+.. +--------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------+---------------------------------------------------------------------+
+.. |                          | Summary of features                                                         | Downloads of the recent files                                   | Links to the latest documents                                       |
+.. +==========================+=============================================================================+=================================================================+=====================================================================+
+.. | CUBRID Manager           | Java client tool for SQL execution & DB operation.                          | `CUBRID Manager Download                                        | `CUBRID Manager Documents                                           |
+.. |                          |                                                                             | <http://ftp.cubrid.org/CUBRID_Tools/CUBRID_Manager>`_           | <http://www.cubrid.org/wiki_tools/entry/cubrid-manager>`_           |   
+.. |                          | 1) Java-based management tool (JRE 1.6 or higher required)                  |                                                                 |                                                                     |
+.. |                          |                                                                             |                                                                 |                                                                     |   
+.. |                          | 2) Auto upgrade after the initial download                                  |                                                                 |                                                                     |
+.. |                          |                                                                             |                                                                 |                                                                     |   
+.. |                          | 3) Useful to manage multiple hosts                                          |                                                                 |                                                                     |
+.. |                          |                                                                             |                                                                 |                                                                     |   
+.. |                          | 4) DB access via CUBRID Manager server                                      |                                                                 |                                                                     |
+.. +--------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------+---------------------------------------------------------------------+
+.. | CUBRID Migration Toolkit | Java-based client tool to migrate schema and data from source DB            | `CUBRID Migration Toolkit Download                              | `CUBRID Migration Toolkit Documents                                 |
+.. |                          | (MySQL, Oracle, CUBRID) to CUBRID.                                          | <http://ftp.cubrid.org/CUBRID_Tools/CUBRID_Migration_Toolkit>`_ | <http://www.cubrid.org/wiki_tools/entry/cubrid-migration-toolkit>`_ |
+.. |                          |                                                                             |                                                                 |                                                                     |   
+.. |                          | 1) Java-based management tool (JRE 1.6 or higher required)                  |                                                                 |                                                                     |
+.. |                          |                                                                             |                                                                 |                                                                     |   
+.. |                          | 2) Auto upgrade after the initial download                                  |                                                                 |                                                                     |
+.. |                          |                                                                             |                                                                 |                                                                     |   
+.. |                          | 3) Available migration only for multiple queries results,                   |                                                                 |                                                                     |
+.. |                          |    the reuse of migration scenario; good to batch job                       |                                                                 |                                                                     |
+.. |                          |                                                                             |                                                                 |                                                                     |   
+.. |                          | 4) Direct DB access with JDBC                                               |                                                                 |                                                                     |
+.. +--------------------------+-----------------------------------------------------------------------------+-----------------------------------------------------------------+---------------------------------------------------------------------+
 
-Because CUBRID 2008 R4.3 or higher version includes Web Manager on the installation package, you can use the Web Manager instantly after the installation of CUBRID DBMS.
 
-#.  Configure the value of **support_web_manager** in cm.conf as "YES".
-
-#.  Start CUBRID Service. Web Manager works normally only when CUBRID Manager server is started. For more information, see :ref:`cubrid-manager-server`. 
-
-    ::
-
-        C:\CUBRID>cubrid service start
-        ++ cubrid service is running.
-
-#.  Access to https://localhost:8001/ which is written on the address bar. Note that the header of address is not http, but https.
-    
-#.  First, log-in to the host. To access to the host, you should perform the CUBRID Manager server user (=the host user)'s authentication primarily. The default user ID/password is admin/admin.
-
-    .. image:: /images/gs_manager_login.png
-
-#.  Connect to the DB server. In the tree on the left, you can see the list of databases which have been generated within the corresponding host. Click the DB name that you want to access and perform the DB user authentication (default ID/password: dba/pressing enter key)
-    
-    .. image:: /images/gs_manager_db.png
-    
-#.  Run the SQL on the access DB and confirm the result. On the left side, the list of connected databases are displayed. You can edit, run, and find the result on the SQL tab.
-
-    .. image:: /images/gs_manager_screen.png
-
-For more information, see http://www.cubrid.org/wiki_tools/entry/cubrid-web-manager-manual\ .
-
-Running SQL with CUBRID Manager Client
---------------------------------------
+Running SQL with CUBRID Manager
+-------------------------------
 
 CUBRID Manager is the client tool that you should download and run. It is a Java application which requires JRE or JDK 1.6 or higher.
 
@@ -197,35 +173,7 @@ CUBRID Manager is the client tool that you should download and run. It is a Java
 
     .. image:: /images/gs_manager_sql.png
 
-For more information, see http://www.cubrid.org/wiki_tools/entry/cubrid-manager-manual_kr\ .
-
-Running SQL with CUBRID Query Browser
--------------------------------------
-
-CUBRID Query Browser (hereafter CQB) is the development tool only for SQL execution, light-weight version of CUBRID Manager (hereafter CM). The differences with CM are as follows:
-
-*   CQB can access DB via JDBC only, without CM server.
-    
-*   As a result, DB/broker operating and monitoring features are not supported.
-    
-*   As a result, CQB only logs in DB user and CM user login is unnecessary.
-    
-*   Running CUBRID Manager server on the server side is unnecessary.
-
-CQB client tool also needs to be downloaded and installed separately from the CUBRID installation package. It is executed on a Java application which requires JRE or JDK 1.6 version or later.
-
-#.  Install the latest CQB file after download. It is compatible with any versions of the engine if you just add the same version's JDBC driver with the DB server. It is recommended to upgrade to the latest version periodically because it supports the auto-update feature.
-    (CUBRID ftp: http://ftp.cubrid.org/CUBRID_Tools/CUBRID_Query_Browser )
-
-#.  Register DB access information on the [File > New Connection] menu after installing CQB. In this case, broker address, broker access port (default: 33,000), DB user, and password should be entered and the JDBC driver which has the same version with DB server should be installed (supporting auto-driver-search/auto-update).
-    
-#.  Try to access as choosing DB. In this case, perform DB authentication (default: dba/pressing enter key).
-    
-#.  Run SQL on the access DB and confirm the result. The lists of Host, DB, and table are displayed on the left side, and the query editor/result window are shown on the right side. You can reuse the SQLs which have been succeeded with [SQL History] tab and compare the multiple results of several DBs as adding the DBs for the comparison of the result with [Multiple Query] tab.
-
-    .. image:: /images/gs_manager_qb.png
-
-For more information, see http://www.cubrid.org/wiki_tools/entry/cubrid-query-browser-manual_kr\ .
+.. FIXME: For more information, see http://www.cubrid.org/wiki_tools/entry/cubrid-manager-manual_kr\ .
 
 Migrating schema/data with CUBRID Migration Toolkit
 ---------------------------------------------------
@@ -249,33 +197,33 @@ It is useful in case of switching from other DB into CUBRID, in case of migratin
 
 .. image:: /images/gs_manager_migration.png
 
-For more information, see http://www.cubrid.org/wiki_tools/entry/cubrid-migration-toolkit-manual\ .
+.. FIXME: For more information, see http://www.cubrid.org/wiki_tools/entry/cubrid-migration-toolkit-manual\ .
 
 Drivers
 =======
 
 The drivers supported by CUBRID are as follows:
 
-*   :doc:`CUBRID JDBC driver <api/jdbc>` (`Downloads JDBC <http://www.cubrid.org/?mid=downloads&item=jdbc_driver>`_)
+*   :doc:`CUBRID JDBC driver <api/jdbc>` (`Downloads JDBC <http://ftp.cubrid.org/CUBRID_Drivers/JDBC_Driver/>`_)
 
-*   :doc:`CUBRID CCI driver <api/cci>` (`Downloads CCI <http://www.cubrid.org?mid=downloads&item=cci_driver>`_)
+*   :doc:`CUBRID CCI driver <api/cci>` (`Downloads CCI <http://ftp.cubrid.org/CUBRID_Drivers/CCI_Driver/>`_)
 
-*   :doc:`CUBRID PHP driver <api/php>` (`Downloads PHP <http://www.cubrid.org/?mid=downloads&item=php_driver&driver_type=phpdr>`_)
+*   :doc:`CUBRID PHP driver <api/php>` (`Downloads PHP <http://ftp.cubrid.org/CUBRID_Drivers/PHP_Driver/>`_)
 
-*   :doc:`CUBRID PDO driver <api/pdo>` (`Downloads PDO <http://www.cubrid.org/?mid=downloads&item=php_driver&driver_type=pdo>`_)
+*   :doc:`CUBRID PDO driver <api/pdo>` (`Downloads PDO <http://ftp.cubrid.org/CUBRID_Drivers/PHP_Driver/PDO/>`_)
 
-*   :doc:`CUBRID ODBC driver <api/odbc>` (`Downloads ODBC <http://www.cubrid.org/?mid=downloads&item=odbc_driver>`_)
+*   :doc:`CUBRID ODBC driver <api/odbc>` (`Downloads ODBC <http://ftp.cubrid.org/CUBRID_Drivers/ODBC_Driver/>`_)
 
-*   :doc:`CUBRID OLE DB driver <api/oledb>` (`Downloads OLE DB <http://www.cubrid.org/?mid=downloads&item=oledb_driver>`_)
+*   :doc:`CUBRID OLE DB driver <api/oledb>` (`Downloads OLE DB <http://ftp.cubrid.org/CUBRID_Drivers/OLEDB_Driver/>`_)
 
-*   :doc:`CUBRID ADO.NET driver <api/adodotnet>` (`Downloads ADO.NET <http://www.cubrid.org/?mid=downloads&item=ado_dot_net_driver>`_)
+*   :doc:`CUBRID ADO.NET driver <api/adodotnet>` (`Downloads ADO.NET <http://ftp.cubrid.org/CUBRID_Drivers/ADO.NET_Driver/>`_)
 
-*   :doc:`CUBRID Perl driver <api/perl>` (`Downloads Perl <http://www.cubrid.org/?mid=downloads&item=perl_driver>`_)
+*   :doc:`CUBRID Perl driver <api/perl>` (`Downloads Perl <http://ftp.cubrid.org/CUBRID_Drivers/Perl_Driver/>`_)
 
-*   :doc:`CUBRID Python driver <api/python>` (`Downloads Python <http://www.cubrid.org/?mid=downloads&item=python_driver>`_)
+*   :doc:`CUBRID Python driver <api/python>` (`Downloads Python <http://ftp.cubrid.org/CUBRID_Drivers/Python_Driver/>`_)
 
-*   :doc:`CUBRID Ruby driver <api/ruby>` (`Downloads Ruby <http://www.cubrid.org/?mid=downloads&item=ruby_driver>`_)
+*   :doc:`CUBRID Ruby driver <api/ruby>` (`Downloads Ruby <http://ftp.cubrid.org/CUBRID_Drivers/Ruby_Driver/>`_)
 
-*   :doc:`CUBRID Node.js driver <api/node_js>` (`Downloads Node.js <http://www.cubrid.org/?mid=downloads&item=nodejs_driver>`_)
+*   :doc:`CUBRID Node.js driver <api/node_js>` (`Downloads Node.js <http://www.cubrid.org/downloads/linux/64-bit/drivers/node-js>`_)
 
 Among above drivers, JDBC and CCI drivers are automatically downloaded while CUBRID is being installed. Thus, you do not have to download them manually.

--- a/en/release_note/index.rst
+++ b/en/release_note/index.rst
@@ -44,9 +44,9 @@ Additional Information
 
 Regarding CUBRID upgrade and migration, see :doc:`/upgrade`.
 
-Regarding CUBRID Tool, see http://www.cubrid.org/wiki_tools\ .
+.. FIXME: Regarding CUBRID Tool, see http://www.cubrid.org/wiki_tools\ .
 
-Regarding CUBRID Drivers, see http://www.cubrid.org/wiki_apis\ . 
+.. FIXME: Regarding CUBRID Drivers, see http://www.cubrid.org/wiki_apis\ . 
 
 Regarding the recent CUBRID sources, visit https://github.com/CUBRID/cubrid and https://github.com/CUBRID\ .
 

--- a/en/sql/datatype.rst
+++ b/en/sql/datatype.rst
@@ -994,7 +994,7 @@ BIT(n)
 
 Fixed-length binary or hexadecimal bit strings are represented as **BIT** (*n*), where *n* is the maximum number of bits. If *n* is not specified, the length is set to 1. If *n* is not specified, the length is set to 1. The bit string is filled with 8-bit unit from the left side. For example, the value of B'1' is the same as the value of B'10000000'. Therefore, it is recommended to declare a length by 8-bit unit, and input a value by 8-bit unit.
 
-.. note:: If you input B'1' to the BIT(4) column, it is printed out X'8' on CSQL, X'80' on CUBRID Manager, Query Browser or application program.
+.. note:: If you input B'1' to the BIT(4) column, it is printed out X'8' on CSQL, X'80' on CUBRID Manager or application program.
 
 *   *n* must be a number greater than 0.
 *   If the length of the string exceeds *n*, it is truncated and filled with 0s.
@@ -1025,7 +1025,7 @@ BIT VARYING(n)
 
 A variable-length bit string is represented as **BIT VARYING** (*n*), where *n* is the maximum number of bits. If *n* is not specified, the length is set to 1,073,741,823 (maximum value). *n* is the maximum number of bits. If *n* is not specified, the maximum length is set to 1,073,741,823. The bit string is filled with 8-bit values from the left side. For example, the value of B'1' is the same as the value of B'10000000'. Therefore, it is recommended to declare a length by 8-bit unit, and input a value by 8-bit unit.
 
-.. note:: If you input B'1' to the BIT VARYING(4) column, it is printed out X'8' on CSQL, X'80' on CUBRID Manager, Query Browser or application program.
+.. note:: If you input B'1' to the BIT VARYING(4) column, it is printed out X'8' on CSQL, X'80' on CUBRID Manager or application program.
 
 *   If the length of the string exceeds *n*, it is truncated and filled with 0s.
 *   The remainder of the string is not filled with 0s even if a bit string smaller than *n* is stored.

--- a/en/sql/tuning.rst
+++ b/en/sql/tuning.rst
@@ -93,7 +93,7 @@ Viewing Query Plan
 
 To view a query plan for a CUBRID SQL query, you can use following methods.
 
-*   Press "show plan" button on CUBRID Manager or CUBRID Query Browser. For how to use CUBRID Manager or CUBRID Query Browser, see `CUBRID Manager Manual <http://www.cubrid.org/wiki_tools/entry/cubrid-manager-manual>`_ or `CUBRID Query Browser Manual <http://www.cubrid.org/wiki_tools/entry/cubrid-query-browser-manual>`_.
+*   Press "show plan" button on CUBRID Manager. 
 
     .. image:: /images/query_plan_on_CM.png
 

--- a/en/start.rst
+++ b/en/start.rst
@@ -8,13 +8,13 @@ CUBRID provides various tools for you to use easily through GUI. You can downloa
 
 If you use the following tools which CUBRID provides, you can use CUBRID features easily through GUI.
 
-*   `CUBRID Query Browser <http://www.cubrid.org/wiki_tools/entry/cubrid-query-browser>`_
+*   CUBRID Manager 
 
-*   `CUBRID Manager <http://www.cubrid.org/wiki_tools/entry/cubrid-manager>`_
+*   CUBRID Migration Toolkit 
 
-*   `CUBRID Web Manager <http://www.cubrid.org/wiki_tools/entry/cubrid-web-manager>`_
+.. FIXME: *   `CUBRID Manager <http://www.cubrid.org/wiki_tools/entry/cubrid-manager>`_
 
-*   `CUBRID Migration Toolkit <http://www.cubrid.org/wiki_tools/entry/cubrid-migration-toolkit>`_
+.. FIXME: *   `CUBRID Migration Toolkit <http://www.cubrid.org/wiki_tools/entry/cubrid-migration-toolkit>`_
 
 CUBRID also provides various drivers such as JDBC, CCI, PHP, PDO, ODBC, OLE DB, ADO.NET, Perl, Python, and Ruby (see API Reference).
 


### PR DESCRIPTION
- temporarily hide broken links (wiki_tools and wiki_apis are missing from new org site)
- remove query browser
- remove web manager