### PR TITLE
[JSON manual] Basic json functions

### DIFF
--- a/en/sql/function/index.rst
+++ b/en/sql/function/index.rst
@@ -15,6 +15,7 @@ Operators and Functions
     string_fn.rst
     numeric_fn.rst
     datetime_fn.rst
+    json_fn.rst
     lob_fn.rst
     typecast_fn.rst
     analysis_fn.rst

--- a/en/sql/function/json_fn.rst
+++ b/en/sql/function/json_fn.rst
@@ -64,8 +64,10 @@ JSON_KEYS
 
 .. function:: JSON_KEYS (json_doc [ , json path])
 
-  The **JSON _KEYS** function returns a json array of all the object keys of the json object at the given path. Json null is returned if the path addresses a json element that is not a json object.
-  If no argument is given, the keys are gathered from the root path ('$'). Returns NULL if json_doc argument is NULL.
+  The **JSON_KEYS** function returns a json array of all the object keys of the json object at the given path.
+  Json null is returned if the path addresses a json element that is not a json object.
+  If json path argument is missing, the keys are gathered from json root element.
+  An error occurs if json path does not exist. Returns NULL if json_doc argument is NULL.
 
 .. code-block:: sql
 
@@ -99,7 +101,9 @@ JSON_DEPTH
 
 .. function:: JSON_DEPTH (json_doc)
 
-  The **JSON_DEPTH** function returns the maximum depth of the json. Depth count starts at 1. The depth level is increased by one by non-empty json arrays or by non-empty json objects. Returns NULL if argument is NULL.
+  The **JSON_DEPTH** function returns the maximum depth of the json.
+  Depth count starts at 1. The depth level is increased by one by non-empty json arrays or by non-empty json objects.
+  Returns NULL if argument is NULL.
 
 .. code-block:: sql
 
@@ -135,7 +139,9 @@ JSON_LENGTH
 
 .. function:: JSON_LENGTH (json_doc [, json path])
 
-  The **JSON_LENGTH** function returns the length of the json element at the given path. If no path argument is given, the returned value is the length of the root json element. Returns NULL if any argument is NULL or if no element exists at the given path.
+  The **JSON_LENGTH** function returns the length of the json element at the given path.
+  If no path argument is given, the returned value is the length of the root json element.
+  Returns NULL if any argument is NULL or if no element exists at the given path.
 
 .. code-block:: sql
 
@@ -178,7 +184,8 @@ JSON_VALID
 
 .. function:: JSON_VALID (val)
 
-  The **JSON_VALID** function returns 1 if the given val argument is a valid json_doc, 0 otherwise. Returns NULL if argument is NULL.
+  The **JSON_VALID** function returns 1 if the given val argument is a valid json_doc, 0 otherwise.
+  Returns NULL if argument is NULL.
 
 .. code-block:: sql
 
@@ -209,6 +216,7 @@ JSON_QUOTE
 .. function:: JSON_QUOTE (str)
 
   Escapes quotes and special characters and surrounds the resulting string in quotes. Returns result as a json_string.
+  Returns NULL if str argument is NULL.
 
 .. code-block:: sql
 
@@ -234,6 +242,7 @@ JSON_UNQUOTE
 .. function:: JSON_UNQUOTE (json_doc)
 
   Unquotes a json_value's json string and returns the resulting string.
+  Returns NULL if json_doc argument is NULL.
   //TODO: NO_BACKSLASH_ESCAPES, escape explainations 
 
 .. code-block:: sql
@@ -259,7 +268,8 @@ JSON_PRETTY
 
 .. function:: JSON_PRETTY (json_doc)
 
-  Returns a string containing the json_doc pretty-printed. Returns NULL if json_doc argument is NULL.
+  Returns a string containing the json_doc pretty-printed.
+  Returns NULL if json_doc argument is NULL.
 
 .. code-block:: sql
 

--- a/en/sql/function/json_fn.rst
+++ b/en/sql/function/json_fn.rst
@@ -243,7 +243,6 @@ JSON_UNQUOTE
 
   Unquotes a json_value's json string and returns the resulting string.
   Returns NULL if json_doc argument is NULL.
-  //TODO: NO_BACKSLASH_ESCAPES, escape explainations 
 
 .. code-block:: sql
 

--- a/en/sql/function/json_fn.rst
+++ b/en/sql/function/json_fn.rst
@@ -1,9 +1,10 @@
-:meta-keywords: cubrid json
+:meta-keywords: cubrid json, json functions
+:meta-description: CUBRID functions that create, query and modify JSON data.
 
 :tocdepth: 3
 
 *********************************
-JSON functions and operators
+JSON functions
 *********************************
 
 .. contents::
@@ -11,9 +12,18 @@ JSON functions and operators
 JSON_ARRAY
 ===================================
 
-.. function:: JSON_ARRAY (val1.., valn)
+.. function:: JSON_ARRAY ([val1 [, val2] ...])
 
-  The **JSON_ARRAY** function creates a json array containing the given val arguments.
+  The **JSON_ARRAY** function returns a json array containing the given list (possibly empty) of values.
+
+.. code-block:: sql
+
+    SELECT JSON_ARRAY();
+::
+
+      json_array()
+    ======================
+      []
 
 .. code-block:: sql
 
@@ -27,9 +37,18 @@ JSON_ARRAY
 JSON_OBJECT
 ===================================
 
-.. function:: JSON_ARRAY (string1 key1, val1 val1.., stringn keyn, valn valn)
+.. function:: JSON_OBJECT ([key1, val1[ , key2, val2] ...])
 
-  The **JSON_OBJECT** function creates a json object containing the given key value pairs given as arguments.
+  The **JSON_OBJECT** function returns a json object containing the given list (possibly empty) of key-value pairs.
+
+.. code-block:: sql
+
+    SELECT JSON_OBJECT();
+::
+
+      json_object()
+    ======================
+      {}
 
 .. code-block:: sql
 
@@ -45,7 +64,16 @@ JSON_DEPTH
 
 .. function:: JSON_DEPTH (json_doc)
 
-  The **JSON_DEPTH** function returns the maximum depth of the json. Any json element of an array or of an object increseases depth by one. Depth count starts at 1. Returns NULL if argument is NULL.
+  The **JSON_DEPTH** function returns the maximum depth of the json. Depth count starts at 1. The depth level is increased by one by non-empty json arrays or by non-empty json objects. Returns NULL if argument is NULL.
+
+.. code-block:: sql
+
+    SELECT JSON_DEPTH('"scalar"');
+::
+
+      json_depth('"scalar"')
+    ======================
+      1
 
 .. code-block:: sql
 
@@ -56,19 +84,57 @@ JSON_DEPTH
     ======================
       3
 
-JSON_LENGTH
-===================================
-
-.. function:: JSON_LENGTH (json_doc, [json path])
-
-  The **JSON_LENGTH** function returns the length of the json element at the given path. If no path argument is given, the returned value is the length of the root json element. Returns NULL if any argument is NULL.
+  Example of a deeper json:
 
 .. code-block:: sql
 
-    SELECT JSON_LENGTH('[{"a":4}, 2]');
+    SELECT JSON_DEPTH('[{"a":[1,2,3,{"k":[4,5]}]},2,3,4,5,6,7]');
 ::
 
-      json_length('[{"a":4}, 2]')
+      json_depth('[{"a":[1,2,3,{"k":[4,5]}]},2,3,4,5,6,7]')
+    ======================
+      6
+
+JSON_LENGTH
+===================================
+
+.. function:: JSON_LENGTH (json_doc [, json path])
+
+  The **JSON_LENGTH** function returns the length of the json element at the given path. If no path argument is given, the returned value is the length of the root json element. Returns NULL if any argument is NULL or if no element exists at the given path.
+
+.. code-block:: sql
+
+    SELECT JSON_LENGTH('"scalar"');
+::
+
+      json_length('"scalar"')
+    ======================
+      1
+
+.. code-block:: sql
+
+    SELECT JSON_LENGTH('[{"a":4}, 2]', '$.a');
+::
+
+      json_length('[{"a":4}, 2]', '$.a')
+    ======================
+      NULL
+
+.. code-block:: sql
+
+    SELECT JSON_LENGTH('[2, {"a":4, "b":4, "c":4}]', '$[1]');
+::
+
+      json_length('[2, {"a":4, "b":4, "c":4}]', '$[1]')
+    ======================
+      3
+
+.. code-block:: sql
+
+    SELECT JSON_LENGTH('[{"a":[1,2,3,{"k":[4,5,6,7,8]}]},2]');
+::
+
+      json_length('[{"a":[1,2,3,{"k":[4,5,6,7,8]}]},2]')
     ======================
       2
 
@@ -85,14 +151,13 @@ JSON_VALID
     1
     SELECT JSON_VALID('{"222":');
     0
-::
 
 JSON_TYPE
 ===================================
 
-.. function:: JSON_TYPE (json_val)
+.. function:: JSON_TYPE (json_doc)
 
-  The **JSON_TYPE** function returns the type of the json_val argument as a string.
+  The **JSON_TYPE** function returns the type of the json_doc argument as a string.
 
 .. code-block:: sql
 
@@ -102,7 +167,6 @@ JSON_TYPE
     'JSON_OBJECT'
     SELECT JSON_TYPE ('"aaa"');
     'STRING'
-::
 
 JSON_QUOTE
 ===================================

--- a/en/sql/function/json_fn.rst
+++ b/en/sql/function/json_fn.rst
@@ -149,7 +149,7 @@ JSON_VALID
 
     SELECT JSON_VALID('[{"a":4}, 2]');
     1
-    SELECT JSON_VALID('{"222":');
+    SELECT JSON_VALID('{"wrong json object":');
     0
 
 JSON_TYPE

--- a/en/sql/function/json_fn.rst
+++ b/en/sql/function/json_fn.rst
@@ -12,7 +12,7 @@ JSON functions
 JSON_ARRAY
 ===================================
 
-.. function:: JSON_ARRAY ([val1 [, val2] ...])
+.. function:: JSON_ARRAY ([val1 [ , val2] ...])
 
   The **JSON_ARRAY** function returns a json array containing the given list (possibly empty) of values.
 
@@ -37,7 +37,7 @@ JSON_ARRAY
 JSON_OBJECT
 ===================================
 
-.. function:: JSON_OBJECT ([key1, val1[ , key2, val2] ...])
+.. function:: JSON_OBJECT ([key1, val1 [ , key2, val2] ...])
 
   The **JSON_OBJECT** function returns a json object containing the given list (possibly empty) of key-value pairs.
 
@@ -137,7 +137,7 @@ JSON_DEPTH
 JSON_LENGTH
 ===================================
 
-.. function:: JSON_LENGTH (json_doc [, json path])
+.. function:: JSON_LENGTH (json_doc [ , json path])
 
   The **JSON_LENGTH** function returns the length of the json element at the given path.
   If no path argument is given, the returned value is the length of the root json element.

--- a/en/sql/function/json_fn.rst
+++ b/en/sql/function/json_fn.rst
@@ -59,6 +59,41 @@ JSON_OBJECT
     ======================
       {"a":1,"b":"1","c":{"a":4},"d":[1,2,3]}
 
+JSON_KEYS
+===================================
+
+.. function:: JSON_KEYS (json_doc [ , json path])
+
+  The **JSON _KEYS** function returns a json array of all the object keys of the json object at the given path. Json null is returned if the path addresses a json element that is not a json object.
+  If no argument is given, the keys are gathered from the root path ('$'). Returns NULL if json_doc argument is NULL.
+
+.. code-block:: sql
+
+    SELECT JSON_KEYS('{}');
+::
+
+      json_keys('{}')
+    ======================
+      []
+
+.. code-block:: sql
+
+    SELECT JSON_KEYS('"non-object"');
+::
+
+      json_keys('"non-object"')
+    ======================
+      null
+
+.. code-block:: sql
+
+    SELECT JSON_KEYS('{"a":1, "b":2, "c":{"d":1}}');
+::
+
+      json_keys('{"a":1, "b":2, "c":{"d":1}}')
+    ======================
+      ["a","b","c"]
+
 JSON_DEPTH
 ===================================
 
@@ -196,7 +231,7 @@ JSON_QUOTE
 JSON_UNQUOTE
 ===================================
 
-.. function:: JSON_UNQUOTE (json_val)
+.. function:: JSON_UNQUOTE (json_doc)
 
   Unquotes a json_value's json string and returns the resulting string.
   //TODO: NO_BACKSLASH_ESCAPES, escape explainations 

--- a/en/sql/function/json_fn.rst
+++ b/en/sql/function/json_fn.rst
@@ -1,0 +1,156 @@
+:meta-keywords: cubrid json
+
+:tocdepth: 3
+
+*********************************
+JSON functions and operators
+*********************************
+
+.. contents::
+
+JSON_ARRAY
+===================================
+
+.. function:: JSON_ARRAY (val1.., valn)
+
+  The **JSON_ARRAY** function creates a json array containing the given val arguments.
+
+.. code-block:: sql
+
+    SELECT JSON_ARRAY(1, '1', json '{"a":4}', json '[1,2,3]');
+::
+
+      json_array(1, '1', json '{"a":4}', json '[1,2,3]')
+    ======================
+      [1,"1",{"a":4},[1,2,3]]
+
+JSON_OBJECT
+===================================
+
+.. function:: JSON_ARRAY (string1 key1, val1 val1.., stringn keyn, valn valn)
+
+  The **JSON_OBJECT** function creates a json object containing the given key value pairs given as arguments.
+
+.. code-block:: sql
+
+    SELECT JSON_OBJECT('a', 1, 'b', '1', 'c', json '{"a":4}', 'd', json '[1,2,3]');
+::
+
+      json_object('a', 1, 'b', '1', 'c', json '{"a":4}', 'd', json '[1,2,3]')
+    ======================
+      {"a":1,"b":"1","c":{"a":4},"d":[1,2,3]}
+
+JSON_DEPTH
+===================================
+
+.. function:: JSON_DEPTH (json_doc)
+
+  The **JSON_DEPTH** function returns the maximum depth of the json. Any json element of an array or of an object increseases depth by one. Depth count starts at 1. Returns NULL if argument is NULL.
+
+.. code-block:: sql
+
+    SELECT JSON_DEPTH('[{"a":4}, 2]');
+::
+
+      json_depth('[{"a":4}, 2]')
+    ======================
+      3
+
+JSON_LENGTH
+===================================
+
+.. function:: JSON_LENGTH (json_doc, [json path])
+
+  The **JSON_LENGTH** function returns the length of the json element at the given path. If no path argument is given, the returned value is the length of the root json element. Returns NULL if any argument is NULL.
+
+.. code-block:: sql
+
+    SELECT JSON_LENGTH('[{"a":4}, 2]');
+::
+
+      json_length('[{"a":4}, 2]')
+    ======================
+      2
+
+JSON_VALID
+===================================
+
+.. function:: JSON_VALID (val)
+
+  The **JSON_VALID** function returns 1 if the given val argument is a json or would be castable to json, 0 otherwise. Returns NULL if argument is NULL.
+
+.. code-block:: sql
+
+    SELECT JSON_VALID('[{"a":4}, 2]');
+    1
+    SELECT JSON_VALID('{"222":');
+    0
+::
+
+JSON_TYPE
+===================================
+
+.. function:: JSON_TYPE (json_val)
+
+  The **JSON_TYPE** function returns the type of the json_val argument as a string.
+
+.. code-block:: sql
+
+    SELECT JSON_TYPE ('[{"a":4}, 2]');
+    'JSON_ARRAY'
+    SELECT JSON_TYPE ('{"a":4}');
+    'JSON_OBJECT'
+    SELECT JSON_TYPE ('"aaa"');
+    'STRING'
+::
+
+JSON_QUOTE
+===================================
+
+.. function:: JSON_QUOTE (str)
+
+  Escapes quotes and special characters and surrounds the resulting string in quotes. Returns result as a json_string.
+
+.. code-block:: sql
+
+    SELECT JSON_QUOTE ('simple');
+::
+
+      json_unquote('simple')
+    ======================
+      '"simple"'
+
+.. code-block:: sql
+
+    SELECT JSON_QUOTE ('"');
+::
+
+      json_unquote('"')
+    ======================
+      '"\""'
+
+JSON_UNQUOTE
+===================================
+
+.. function:: JSON_UNQUOTE (json_val)
+
+  Unquotes a json_value's json string and returns the resulting string.
+  //TODO: NO_BACKSLASH_ESCAPES, escape explainations 
+
+.. code-block:: sql
+
+    SELECT JSON_UNQUOTE ('"\\u0032"');
+::
+
+      json_unquote('"\u0032"')
+    ======================
+      '2'
+
+.. code-block:: sql
+
+    SELECT JSON_UNQUOTE ('"\\""');
+::
+
+      json_unquote('"\""')
+    ======================
+      '"'

--- a/en/sql/function/json_fn.rst
+++ b/en/sql/function/json_fn.rst
@@ -253,3 +253,33 @@ JSON_UNQUOTE
       json_unquote('"\""')
     ======================
       '"'
+
+JSON_PRETTY
+===================================
+
+.. function:: JSON_PRETTY (json_doc)
+
+  Returns a string containing the json_doc pretty-printed. Returns NULL if json_doc argument is NULL.
+
+.. code-block:: sql
+
+    SELECT JSON_PRETTY('[{"a":"val1", "b":"val2", "c": [1, "elem2", 3, 4, {"key":"val"}]}]');
+::
+
+      json_pretty('[{"a":"val1", "b":"val2", "c": [1, "elem2", 3, 4, {"key":"val"}]}]')
+    ======================
+      '[
+      {
+        "a": "val1",
+        "b": "val2",
+        "c": [
+          1,
+          "elem2",
+          3,
+          4,
+          {
+            "key": "val"
+          }
+        ]
+      }
+    ]'

--- a/en/sql/function/json_fn.rst
+++ b/en/sql/function/json_fn.rst
@@ -1,4 +1,4 @@
-:meta-keywords: cubrid json, json functions
+:meta-keywords: cubrid json, json functions, database json
 :meta-description: CUBRID functions that create, query and modify JSON data.
 
 :tocdepth: 3
@@ -143,7 +143,7 @@ JSON_VALID
 
 .. function:: JSON_VALID (val)
 
-  The **JSON_VALID** function returns 1 if the given val argument is a json or would be castable to json, 0 otherwise. Returns NULL if argument is NULL.
+  The **JSON_VALID** function returns 1 if the given val argument is a valid json_doc, 0 otherwise. Returns NULL if argument is NULL.
 
 .. code-block:: sql
 


### PR DESCRIPTION
Add simple json functions to manual's function subsection:

JSON_ARRAY
JSON_OBJECT
JSON_KEYS
JSON_DEPTH
JSON_LENGTH
JSON_VALID
JSON_TYPE
JSON_QUOTE
JSON_UNQUOTE
JSON_PRETTY