### PR TITLE
[CBRD-23494] load index online stats

### DIFF
--- a/en/admin/admin_utils.rst
+++ b/en/admin/admin_utils.rst
@@ -1674,6 +1674,45 @@ The following shows [options] available with the **cubrid statdump** utility.
     | ..bt_vacuum_insid_traverse               | Counter/timer  | The number and duration of B-tree traverse for vacuum 'insert id'     |
     +------------------------------------------+----------------+-----------------------------------------------------------------------+
 
+    **Load Index Online**
+
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | **Stat name**                                      | **Stat type**  |  **Description**                                                      |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts                           | Accumulator    | The number of key inserts by index loader                             |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts_same_page_hold            | Accumulator    | The number of successive inserts by index loader in same leaf page    |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts_reject_no_more_keys       | Accumulator    | The number of same leaf rejected inserts due to no more keys          |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts_reject_max_key_len        | Accumulator    | The number of same leaf rejected inserts because of key length        |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts_reject_no_space           | Accumulator    | The number of same leaf rejected inserts because of not enough space  |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_release_latch                     | Accumulator    | The number of same leaf rejected inserts to allow others latch page   |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts_reject_key_not_in_range1  | Accumulator    | | The number of same leaf rejected inserts because key is smaller     |
+    |                                                    |                | | than parents boundaries                                             |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts_reject_key_not_in_range2  | Accumulator    | | The number of same leaf rejected inserts because key is greater     |
+    |                                                    |                | | than parents boundaries                                             |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts_reject_key_not_in_range3  | Accumulator    | | The number of same leaf rejected inserts because key failed quick   |
+    |                                                    |                | | min/max check                                                       |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts_reject_key_not_in_range4  | Accumulator    | | The number of same leaf rejected inserts because key doesn't belong |
+    |                                                    |                | | to current leaf page                                                |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | ..btree_online                                     | Counter/timer  | The number and duration of B-tree online index loading                |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | ..btree_online_insert_task                         | Counter/timer  | The number and duration of batch insert tasks by index loader         |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | ..btree_online_prepare_task                        | Counter/timer  | The number and duration of preparing (sorting) index loader tasks     |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | ..btree_online_insert_same_leaf                    | Counter/timer  | | The number and duration of leaf pages processed by index loader     |
+    |                                                    |                | | (multiple keys may be inserted while a leaf page is processed)      |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+
     **Query**
 
     +------------------------------------------+----------------+-----------------------------------------------------------------------+

--- a/en/admin/admin_utils.rst
+++ b/en/admin/admin_utils.rst
@@ -1679,39 +1679,26 @@ The following shows [options] available with the **cubrid statdump** utility.
     +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
     | **Stat name**                                      | **Stat type**  |  **Description**                                                      |
     +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | Num_btree_online_inserts                           | Accumulator    | The number of key inserts by index loader                             |
-    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | Num_btree_online_inserts_same_page_hold            | Accumulator    | The number of successive inserts by index loader in same leaf page    |
-    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | Num_btree_online_inserts_reject_no_more_keys       | Accumulator    | The number of same leaf rejected inserts due to no more keys          |
-    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | Num_btree_online_inserts_reject_max_key_len        | Accumulator    | The number of same leaf rejected inserts because of key length        |
-    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | Num_btree_online_inserts_reject_no_space           | Accumulator    | The number of same leaf rejected inserts because of not enough space  |
-    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | Num_btree_online_release_latch                     | Accumulator    | The number of same leaf rejected inserts to allow others latch page   |
-    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | Num_btree_online_inserts_reject_key_not_in_range1  | Accumulator    | | The number of same leaf rejected inserts because key is smaller     |
-    |                                                    |                | | than parents boundaries                                             |
-    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | Num_btree_online_inserts_reject_key_not_in_range2  | Accumulator    | | The number of same leaf rejected inserts because key is greater     |
-    |                                                    |                | | than parents boundaries                                             |
-    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | Num_btree_online_inserts_reject_key_not_in_range3  | Accumulator    | | The number of same leaf rejected inserts because key failed quick   |
-    |                                                    |                | | min/max check                                                       |
-    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | Num_btree_online_inserts_reject_key_not_in_range4  | Accumulator    | | The number of same leaf rejected inserts because key doesn't belong |
-    |                                                    |                | | to current leaf page                                                |
-    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | ..btree_online                                     | Counter/timer  | The number and duration of B-tree online index loading                |
+    | ..btree_online_load                                | Counter/timer  | The number and duration of B-tree online index loading statements     |
     +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
     | ..btree_online_insert_task                         | Counter/timer  | The number and duration of batch insert tasks by index loader         |
     +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
     | ..btree_online_prepare_task                        | Counter/timer  | The number and duration of preparing (sorting) index loader tasks     |
     +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
-    | ..btree_online_insert_same_leaf                    | Counter/timer  | | The number and duration of leaf pages processed by index loader     |
+    | ..btree_online_insert_leaf                         | Counter/timer  | | The number and duration of leaf pages processed by index loader     |
     |                                                    |                | | (multiple keys may be inserted while a leaf page is processed)      |
     +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts                           | Accumulator    | The number of key inserts by index loader                             |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts_same_page_hold            | Accumulator    | |  The number of successive inserts by index loader in same leaf page |
+    |                                                    |                | | (loader optimization to avoid expensive index traversals)           |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts_retry                     | Accumulator    | | The number of restarted inserts because successive keys do not      |
+    |                                                    |                | | belong to same leaf or because there is not enough space            |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+    | Num_btree_online_inserts_retry_nice                | Accumulator    | The number of restarted inserts to let others access leaf page        |
+    +----------------------------------------------------+----------------+-----------------------------------------------------------------------+
+
 
     **Query**
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23494

I think there is room for improvement regarding online index stats:

  - some may be renamed for clarity (some stats are too long or names are misleading)
  - they should be reordered based on relevance (e.g. btree_online stat should be first, "same page" stats last).
  - some stats may be removed; I have not added Num_btree_online_inserts_reject_key_false_failed_range1, Num_btree_online_inserts_reject_key_false_failed_range2, but also Num_btree_online_inserts_reject_no_more_keys and some of Num_btree_online_inserts_reject_key_not_in_range should be considered for removal.

@razvanradulescu please advise