### PR TITLE
[CBRD-23654] Change ignoring pattern for korean manual

### DIFF
--- a/ko/conf.py
+++ b/ko/conf.py
@@ -286,7 +286,7 @@ texinfo_documents = [
 linkcheck_ignore = [
   r'https://github.com/CUBRID/cubrid/.*', 
   r'http://jira.cubrid.org/browse/.*',
-  r'https://www.apachelounge.com/download/win64/binaries/.*'
+  r'https://www.apachelounge.com/.*'
 ]
 
 linkcheck_timeout = 30


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23654
It fixed ignoring url pattern for Korean manual.