### PR TITLE
Revert "[CBRD-23674] modification of English manual by changing the maximum value of the ha_apply_max_mem_size property. (#119)"

### DIFF
--- a/en/ha.rst
+++ b/en/ha.rst
@@ -677,7 +677,7 @@ To prevent wasting needless disk space, it is recommended to keep this value as 
 
 **ha_apply_max_mem_size**
 
-**ha_apply_max_mem_size** is a parameter used to configure the value of maximum memory that the replication log reflection process of CUBRID HA can use. The default value is **500** (unit: MB) and the maximum value is **INT_MAX** (2147483647). When the value is larger than the size allowed by the system, memory allocation fails and the HA replication reflection process may malfunction. For this reason, you must check whether or not the memory resource can handle the specified value before setting it.
+**ha_apply_max_mem_size** is a parameter used to configure the value of maximum memory that the replication log reflection process of CUBRID HA can use. The default and maximum values are **500** (unit: MB). When the value is larger than the size allowed by the system, memory allocation fails and the HA replication reflection process may malfunction. For this reason, you must check whether or not the memory resource can handle the specified value before setting it.
 
 **ha_applylogdb_ignore_error_list**
 

--- a/en/upgrade.rst
+++ b/en/upgrade.rst
@@ -241,6 +241,10 @@ Parameter configuration
 *   In **KEEP_CONNECTION** parameter, **OFF** value should be changed as **ON** or **AUTO** since **OFF** setting value is no longer used. 
 *   **SELECT_AUTO_COMMIT** should be deleted since this parameter is no longer used.
 *   The value of **APPL_SERVER_MAX_SIZE_HARD_LIMIT** should be 2,097,151 or less since the maximum value of **APPL_SERVER_MAX_SIZE_HARD_LIMIT** is 2,097,151.
+    
+**cubrid_ha.conf**
+
+*   Users who have configured the **ha_apply_max_mem_size** parameter value more than 500 must the value to 500 or less.
 
 **Environment variable**
 


### PR DESCRIPTION
Reverts CUBRID/cubrid-manual#136