### PR TITLE
[CBRD-23721] Fix Python tutorial exec error (Eng/Kor)

### DIFF
--- a/en/api/python.rst
+++ b/en/api/python.rst
@@ -89,6 +89,7 @@ Python Sample Program
 This sample program will show steps that you need to perform in order to connect to the CUBRID database and run SQL statements from Python programming language. Enter the command line below to create a new table in your database. ::
 
     csql -u dba -c "CREATE TABLE posts( id integer, title varchar(255), body string, last_updated timestamp );" demodb
+    csql -u dba -c "grant ALL PRIVILEGES on posts to public;" demodb
 
 **Connecting to demodb from Python**
 
@@ -102,7 +103,7 @@ This sample program will show steps that you need to perform in order to connect
     
     .. code-block:: python
     
-        conn = CUBRIDdb.connect('CUBRID:localhost:30000:dba::')
+        conn = CUBRIDdb.connect('CUBRID:localhost:30000:demodb:dba::')
 
 For the *demodb* database, it is not required to enter any password. In a real-world scenario, you will have to provide the password to successfully connect. 
 The syntax to use the `connect <https://pythonhosted.org/CUBRID-Python/_cubrid-module.html#connect>`_ () function is as follows: ::
@@ -113,23 +114,23 @@ If the database has not started and you try to connect to it, you will receive a
 
     Traceback (most recent call last):
       File "tutorial.py", line 3, in <module>
-        conn = CUBRIDdb.connect('CUBRID:localhost:30000:dba::')
-      File "/usr/local/lib/python2.6/site-packages/CUBRIDdb/__init__.py", line 48, in Connect
+        conn = CUBRIDdb.connect('CUBRID:localhost:30000:demodb:dba::')
+      File "/usr/local/lib/python3.5/site-packages/CUBRIDdb/__init__.py", line 61, in Connect
         return Connection(*args, **kwargs)
-      File "/usr/local/lib/python2.6/site-packages/CUBRIDdb/connections.py", line 19, in __init__
-        self._db = _cubrid.connect(*args, **kwargs)
-    _cubrid.Error: (-1, 'ERROR: DBMS, 0, Unknown DBMS Error')
+      File "/usr/local/lib/python3.5/site-packages/CUBRIDdb/connections.py", line 22, in __init__
+        self.connection = _cubrid.connect(*args, **kwargs2)
+    _cubrid.OperationalError: (-677, "ERROR: DBMS, -677, Failed to connect to database server, 'demodb', on the following host(s): localhost:localhost[CAS INFO-127.0.0.1:30000,0,0].")
 
 If you provide wrong credentials, you will receive an error such as this: ::
 
     Traceback (most recent call last):
       File "tutorial.py", line 3, in <module>
-        con = CUBRIDdb.connect('CUBRID:localhost:33000:demodb','a','b')
-      File "/usr/local/lib/python2.6/site-packages/CUBRIDdb/__init__.py", line 48, in Connect
+        con = CUBRIDdb.connect('CUBRID:localhost:33000:demodb:::','a','b')
+      File "/usr/local/lib/python3.5/site-packages/CUBRIDdb/__init__.py", line 61, in Connect
         return Connection(*args, **kwargs)
-      File "/usr/local/lib/python2.6/site-packages/CUBRIDdb/connections.py", line 19, in __init__
-        self._db = _cubrid.connect(*args, **kwargs)
-    _cubrid.Error: (-1, 'ERROR: DBMS, 0, Unknown DBMS Error')
+      File "/usr/local/lib/python3.5/site-packages/CUBRIDdb/connections.py", line 22, in __init__
+        self.connection = _cubrid.connect(*args, **kwargs2)
+    _cubrid.DatabaseError: (-165, 'ERROR: DBMS, -165, User "a" is invalid.[CAS INFO-127.0.0.1:33000,0,0].')
 
 **Executing an INSERT Statement**
 
@@ -155,7 +156,7 @@ The entire script up to now looks like this:
 .. code-block:: python
 
     import CUBRIDdb
-    conn = CUBRIDdb.connect('CUBRID:localhost:33000:demodb', 'public', '')
+    conn = CUBRIDdb.connect('CUBRID:localhost:33000:demodb:::', 'public', '')
     cur = conn.cursor()
      
     # Plain insert statement
@@ -176,7 +177,7 @@ You can fetch entire records at a time by using the `fetchall <https://pythonhos
     cur.execute("SELECT * FROM posts ORDER BY last_updated")
     rows = cur.fetchall()
     for row in rows:
-        print row
+        print (row)
 
 This will return the two rows inserted earlier in the following form: ::
 
@@ -192,7 +193,7 @@ In a scenario where a lot of data must be returned into the cursor, you can fetc
     cur.execute("SELECT * FROM posts")
     row = cur.fetchone()
     while row:
-        print row
+        print (row)
         row = cur.fetchone()
 
 **Fetching as many as records desired at a time**
@@ -204,7 +205,7 @@ You can fetch a specified number of records at a time by using the `fetchmany <h
     cur.execute("SELECT * FROM posts")
     rows = cur.fetchmany(3)
     for row in rows:
-        print row
+        print (row)
 
 **Accessing Metadata on the Returned Data**
 
@@ -213,7 +214,7 @@ If it is necessary to get information about column attributes of the obtained re
 .. code-block:: python
 
     for description in cur.description:
-        print description
+        print (description)
 
 The output of the script is as follows: ::
 

--- a/ko/api/python.rst
+++ b/ko/api/python.rst
@@ -89,6 +89,7 @@ Python 예제 프로그램
 여기에서는 Python으로 CUBRID 데이터베이스에 대한 작업을 수행하는 예제 프로그램을 작성한다. 예제로 다음과 같은 테이블을 생성한다. ::
 
     csql -u dba -c "CREATE TABLE posts( id integer, title varchar(255), body string, last_updated timestamp );" demodb
+    csql -u dba -c "grant ALL PRIVILEGES on posts to public;" demodb
 
 **Python에서 demodb에 연결**
 
@@ -102,7 +103,7 @@ Python 예제 프로그램
     
     .. code-block:: python
     
-        conn = CUBRIDdb.connect('CUBRID:localhost:30000:dba::')
+        conn = CUBRIDdb.connect('CUBRID:localhost:30000:demodb:dba::')
 
 *demodb* 데이터베이스는 비밀번호가 필요하지 않으므로 비밀번호를 입력하지 않았다. 그러나 실제 데이터베이스에 연결할 때에는 비밀번호가 필요하다면 비밀번호를 입력해야 한다.
 `connect <https://pythonhosted.org/CUBRID-Python/_cubrid-module.html#connect>`_ () 함수의 구문은 다음과 같다. ::
@@ -113,23 +114,23 @@ Python 예제 프로그램
 
     Traceback (most recent call last):
       File "tutorial.py", line 3, in <module>
-        conn = CUBRIDdb.connect('CUBRID:localhost:30000:dba::')
-      File "/usr/local/lib/python2.6/site-packages/CUBRIDdb/__init__.py", line 48, in Connect
+        conn = CUBRIDdb.connect('CUBRID:localhost:30000:demodb:dba::')
+      File "/usr/local/lib/python3.5/site-packages/CUBRIDdb/__init__.py", line 61, in Connect
         return Connection(*args, **kwargs)
-      File "/usr/local/lib/python2.6/site-packages/CUBRIDdb/connections.py", line 19, in __init__
-        self._db = _cubrid.connect(*args, **kwargs)
-    _cubrid.Error: (-1, 'ERROR: DBMS, 0, Unknown DBMS Error')
+      File "/usr/local/lib/python3.5/site-packages/CUBRIDdb/connections.py", line 22, in __init__
+        self.connection = _cubrid.connect(*args, **kwargs2)
+    _cubrid.OperationalError: (-677, "ERROR: DBMS, -677, Failed to connect to database server, 'demodb', on the following host(s): localhost:localhost[CAS INFO-127.0.0.1:30000,0,0].")
 
 자격이 잘못되었다면 다음과 같은 오류가 발생한다. ::
 
     Traceback (most recent call last):
       File "tutorial.py", line 3, in <module>
-        con = CUBRIDdb.connect('CUBRID:localhost:33000:demodb','a','b')
-      File "/usr/local/lib/python2.6/site-packages/CUBRIDdb/__init__.py", line 48, in Connect
+        con = CUBRIDdb.connect('CUBRID:localhost:33000:demodb:::','a','b')
+      File "/usr/local/lib/python3.5/site-packages/CUBRIDdb/__init__.py", line 61, in Connect
         return Connection(*args, **kwargs)
-      File "/usr/local/lib/python2.6/site-packages/CUBRIDdb/connections.py", line 19, in __init__
-        self._db = _cubrid.connect(*args, **kwargs)
-    _cubrid.Error: (-1, 'ERROR: DBMS, 0, Unknown DBMS Error')
+      File "/usr/local/lib/python3.5/site-packages/CUBRIDdb/connections.py", line 22, in __init__
+        self.connection = _cubrid.connect(*args, **kwargs2)
+    _cubrid.DatabaseError: (-165, 'ERROR: DBMS, -165, User "a" is invalid.[CAS INFO-127.0.0.1:33000,0,0].')
 
 **INSERT 문 실행**
 
@@ -155,7 +156,7 @@ CUBRID Python 드라이버에서는 기본적으로 자동 커밋 모드가 비�
 .. code-block:: python
 
     import CUBRIDdb
-    conn = CUBRIDdb.connect('CUBRID:localhost:33000:demodb', 'public', '')
+    conn = CUBRIDdb.connect('CUBRID:localhost:33000:demodb:::', 'public', '')
     cur = conn.cursor()
      
     # Plain insert statement
@@ -176,7 +177,7 @@ CUBRID Python 드라이버에서는 기본적으로 자동 커밋 모드가 비�
     cur.execute("SELECT * FROM posts ORDER BY last_updated")
     rows = cur.fetchall()
     for row in rows:
-        print row
+        print (row)
 
 위 코드는 다음과 같은 내용을 출력한다. ::
 
@@ -192,7 +193,7 @@ CUBRID Python 드라이버에서는 기본적으로 자동 커밋 모드가 비�
     cur.execute("SELECT * FROM posts")
     row = cur.fetchone()
     while row:
-        print row
+        print (row)
         row = cur.fetchone()
 
 **레코드 개수를 지정하여 조회**
@@ -204,7 +205,7 @@ CUBRID Python 드라이버에서는 기본적으로 자동 커밋 모드가 비�
     cur.execute("SELECT * FROM posts")
     rows = cur.fetchmany(3)
     for row in rows:
-        print row
+        print (row)
 
 **반환된 데이터의 메타데이터에 접근**
 
@@ -213,7 +214,7 @@ CUBRID Python 드라이버에서는 기본적으로 자동 커밋 모드가 비�
 .. code-block:: python
 
     for description in cur.description:
-        print description
+        print (description)
 
 위 코드는 다음과 같은 내용을 출력한다. ::
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23721
**Fix python code execution errors in Python tutorial of following style:**
* missing dbname in connect
```
      - conn = CUBRIDdb.connect('CUBRID:localhost:30000:dba::')
      + conn = CUBRIDdb.connect('CUBRID:localhost:30000:demodb:dba::')
```
   * Prevent errors due to insufficient privileges in subsequent insert queries on table **posts** as **public**
```
        csql -u dba -c "CREATE TABLE posts( id integer, title varchar(255), body string, last_updated timestamp );" demodb
      + csql -u dba -c "grant ALL PRIVILEGES on posts to public;" demodb
```
* Python3 style print
```
  for row in rows:
      - print row
      + print (row)
```
