### PR TITLE
[CUBRIDMAN-15] Build fail with python3

### DIFF
--- a/en/_templates_org/layout.html
+++ b/en/_templates_org/layout.html
@@ -60,7 +60,7 @@
       {% set my_keys = title + ', ' + docstitle %}
       {% set my_desc = title + ' &mdash; ' + docstitle + '.' %}
       {% if meta is defined %}
-          {% set meta_keys = meta.keys() %}
+        {% set meta_keys = meta.keys() %}
         {% if 'meta-keywords' in meta_keys %}
           {% set my_keys = my_keys + ', ' + meta.get('meta-keywords') %}
         {% endif %}

--- a/en/_templates_org/layout.html
+++ b/en/_templates_org/layout.html
@@ -57,16 +57,23 @@
     <!-- naver analytics end-->
     
     <!-- meta-tags -->
+      {% import sys %}
       {% set my_keys = title + ', ' + docstitle %}
       {% set my_desc = title + ' &mdash; ' + docstitle + '.' %}
       {% if meta is defined %}
-        {% if 'meta-keywords' in meta.viewkeys() %}
+        {% if sys.version_info[0] == 3 %}
+          {% set meta_keys = meta.keys() %}
+        {% else %}
+          {% set meta_keys = meta.viewkeys() %}
+        {% endif %}
+        {% if 'meta-keywords' in meta_keys %}
           {% set my_keys = my_keys + ', ' + meta.get('meta-keywords') %}
         {% endif %}
-        {%if 'meta-description' in meta.viewkeys() %}
+        {%if 'meta-description' in meta_keys %}
           {% set my_desc = my_desc + ' ' + meta.get('meta-description') %}
         {% endif %}
       {% endif %}
+
       <!-- keywords & description -->
       <meta name="keywords" content="{{ my_keys }}" />
       <meta name="description" content = "{{ my_desc }} " />

--- a/en/_templates_org/layout.html
+++ b/en/_templates_org/layout.html
@@ -57,19 +57,14 @@
     <!-- naver analytics end-->
     
     <!-- meta-tags -->
-      {% import sys %}
       {% set my_keys = title + ', ' + docstitle %}
       {% set my_desc = title + ' &mdash; ' + docstitle + '.' %}
       {% if meta is defined %}
-        {% if sys.version_info[0] == 3 %}
           {% set meta_keys = meta.keys() %}
-        {% else %}
-          {% set meta_keys = meta.viewkeys() %}
-        {% endif %}
         {% if 'meta-keywords' in meta_keys %}
           {% set my_keys = my_keys + ', ' + meta.get('meta-keywords') %}
         {% endif %}
-        {%if 'meta-description' in meta_keys %}
+        {% if 'meta-description' in meta_keys %}
           {% set my_desc = my_desc + ' ' + meta.get('meta-description') %}
         {% endif %}
       {% endif %}

--- a/ko/_templates_org/layout.html
+++ b/ko/_templates_org/layout.html
@@ -57,19 +57,14 @@
     <!-- naver analytics end-->
     
     <!-- meta-tags -->
-      {% import sys %}
       {% set my_keys = title + ', ' + docstitle %}
       {% set my_desc = title + ' &mdash; ' + docstitle + '.' %}
       {% if meta is defined %}
-        {% if sys.version_info[0] == 3 %}
-          {% set meta_keys = meta.keys() %}
-        {% else %}
-          {% set meta_keys = meta.viewkeys() %}
-        {% endif %}
+        {% set meta_keys = meta.keys() %}
         {% if 'meta-keywords' in meta_keys %}
           {% set my_keys = my_keys + ', ' + meta.get('meta-keywords') %}
         {% endif %}
-        {%if 'meta-description' in meta_keys %}
+        {% if 'meta-description' in meta_keys %}
           {% set my_desc = my_desc + ' ' + meta.get('meta-description') %}
         {% endif %}
       {% endif %}

--- a/ko/_templates_org/layout.html
+++ b/ko/_templates_org/layout.html
@@ -57,16 +57,23 @@
     <!-- naver analytics end-->
     
     <!-- meta-tags -->
+      {% import sys %}
       {% set my_keys = title + ', ' + docstitle %}
       {% set my_desc = title + ' &mdash; ' + docstitle + '.' %}
       {% if meta is defined %}
-        {% if 'meta-keywords' in meta.viewkeys() %}
+        {% if sys.version_info[0] == 3 %}
+          {% set meta_keys = meta.keys() %}
+        {% else %}
+          {% set meta_keys = meta.viewkeys() %}
+        {% endif %}
+        {% if 'meta-keywords' in meta_keys %}
           {% set my_keys = my_keys + ', ' + meta.get('meta-keywords') %}
         {% endif %}
-        {%if 'meta-description' in meta.viewkeys() %}
+        {%if 'meta-description' in meta_keys %}
           {% set my_desc = my_desc + ' ' + meta.get('meta-description') %}
         {% endif %}
       {% endif %}
+
       <!-- keywords & description -->
       <meta name="keywords" content="{{ my_keys }}" />
       <meta name="description" content = "{{ my_desc }} " />


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-15

Fixed embedded python code in templates_org/layout.html to use .keys() to make the build succeed on python 3.