### PR TITLE
Revert "[CUBRIDMAN-19] update jdbc_driver usage (eng/kor)"

### DIFF
--- a/en/api/jdbc.rst
+++ b/en/api/jdbc.rst
@@ -29,7 +29,7 @@ You can verify the version of JDBC driver as follows: ::
     cubrid/sql/
     cubrid/jdbc/driver/CUBRIDBlob.class
     ...
-    CUBRID-JDBC-10.2.2.8874
+    CUBRID-JDBC-8.3.1.1032
 
 **Registering CUBRID JDBC Driver**
 
@@ -604,7 +604,7 @@ The line "a" in the example 1 is where data of collection types (**SET**, **MULT
                Connection con = DriverManager.getConnection(url,user,passwd);
                Statement stmt = con.createStatement();
                CUBRIDResultSet rs = (CUBRIDResultSet) stmt.executeQuery(sql);
-               CUBRIDResultSetMetaData rsmd = (CUBRIDResultSetMetaData) rs.getMetaData();
+               CUBRIDResultSetMetaData rsmd = (CUBRIDResultSetMetaData) rs.getMeta Data();
                int numbOfColumn = rsmd.getColumnCount();
                while (rs.next ()) {
                    for (int j=1; j<=numbOfColumn; j++ ) {
@@ -664,15 +664,15 @@ The line "a" in the example 1 is where data of collection types (**SET**, **MULT
                CUBRIDResultSet rs = (CUBRIDResultSet)stmt.executeQuery(sql);
                while (rs.next ()) {
                    CUBRIDOID oid = rs.getOID(1);
-				   oid.addToSet("settest", Integer.valueOf(10));
-				   oid.addToSet("multisettest", Integer.valueOf(20));
-				   oid.addToSequence("listtest", 1, Integer.valueOf(30));
-				   oid.addToSequence("listtest", 100, Integer.valueOf(100));
-				   oid.putIntoSequence("listtest", 99, Integer.valueOf(99));
-				   oid.removeFromSet("settest", Integer.valueOf(1));
-				   oid.removeFromSet("multisettest", Integer.valueOf(2));
-				   oid.removeFromSequence("listtest", 99);
-				   oid.removeFromSequence("listtest", 1);
+                   oid.addToSet("settest",new Integer(10));
+                   oid.addToSet("multisettest",new Integer(20));
+                   oid.addToSequence("listtest",1,new Integer(30));
+                   oid.addToSequence("listtest",100,new Integer(100));
+                   oid.putIntoSequence("listtest",99,new Integer(99));
+                   oid.removeFromSet("settest",new Integer(1));
+                   oid.removeFromSet("multisettest",new Integer(2));
+                   oid.removeFromSequence("listtest",99);
+                   oid.removeFromSequence("listtest",1);
                }
                con.commit();
                rs.close();
@@ -1308,7 +1308,7 @@ The following is an example which connects to *demodb*, creates a table, execute
                stmt = conn.createStatement();
                stmt.executeUpdate("CREATE TABLE xoo ( a INT, b INT, c CHAR(10))");
      
-               preStmt = conn.prepareStatement("INSERT INTO xoo VALUES(?,?,'100')");
+               preStmt = conn.prepareStatement("INSERT INTO xoo VALUES(?,?,''''100'''')");
                preStmt.setInt (1, 1) ;
                preStmt.setInt (2, 1*10) ;
                int rst = preStmt.executeUpdate () ;

--- a/en/api/python.rst
+++ b/en/api/python.rst
@@ -51,7 +51,7 @@ To install CUBRID Python driver by compiling source code, you should have Python
 
 **Using a Package Manager (EasyInstall) of CUBRID Python Driver (Linux)**
 
-EasyInstall is a Python module (**easy_install**) bundled with **setuptools** that lets you automatically download, build, install, and manage Python packages. It gives you a quick way to install packages remotely by connecting to other websites via HTTP as well as connecting to the Package Index. It is somewhat analogous to the CPAN and PEAR tools for Perl and PHP, respectively. For more information about EasyInstall, see https://setuptools.readthedocs.io/en/latest/deprecated/easy_install.html.
+EasyInstall is a Python module (**easy_install**) bundled with **setuptools** that lets you automatically download, build, install, and manage Python packages. It gives you a quick way to install packages remotely by connecting to other websites via HTTP as well as connecting to the Package Index. It is somewhat analogous to the CPAN and PEAR tools for Perl and PHP, respectively. For more information about EasyInstall, see https://setuptools.readthedocs.io/en/latest/easy_install.html.
 
 Enter the command below to install CUBRID Python driver by using EasyInstall. ::
 

--- a/ko/api/jdbc.rst
+++ b/ko/api/jdbc.rst
@@ -29,7 +29,7 @@ JDBC 드라이버 버전은 다음과 같은 방법으로 확인할 수 있다. 
     cubrid/sql/
     cubrid/jdbc/driver/CUBRIDBlob.class
     ...
-    CUBRID-JDBC-10.2.2.8874
+    CUBRID-JDBC-8.3.1.1032
 
 **CUBRID JDBC 드라이버 등록**
 
@@ -607,7 +607,7 @@ OID를 사용할 때 다음의 규칙을 지켜야 한다.
                Connection con = DriverManager.getConnection(url,user,passwd);
                Statement stmt = con.createStatement();
                CUBRIDResultSet rs = (CUBRIDResultSet) stmt.executeQuery(sql);
-               CUBRIDResultSetMetaData rsmd = (CUBRIDResultSetMetaData) rs.getMetaData();
+               CUBRIDResultSetMetaData rsmd = (CUBRIDResultSetMetaData) rs.getMeta Data();
                int numbOfColumn = rsmd.getColumnCount();
                while (rs.next ()) {
                    for (int j=1; j<=numbOfColumn; j++ ) {
@@ -667,15 +667,15 @@ OID를 사용할 때 다음의 규칙을 지켜야 한다.
                CUBRIDResultSet rs = (CUBRIDResultSet)stmt.executeQuery(sql);
                while (rs.next ()) {
                    CUBRIDOID oid = rs.getOID(1);
-				   oid.addToSet("settest", Integer.valueOf(10));
-				   oid.addToSet("multisettest", Integer.valueOf(20));
-				   oid.addToSequence("listtest", 1, Integer.valueOf(30));
-				   oid.addToSequence("listtest", 100, Integer.valueOf(100));
-				   oid.putIntoSequence("listtest", 99, Integer.valueOf(99));
-				   oid.removeFromSet("settest", Integer.valueOf(1));
-				   oid.removeFromSet("multisettest", Integer.valueOf(2));
-				   oid.removeFromSequence("listtest", 99);
-				   oid.removeFromSequence("listtest", 1);
+                   oid.addToSet("settest",new Integer(10));
+                   oid.addToSet("multisettest",new Integer(20));
+                   oid.addToSequence("listtest",1,new Integer(30));
+                   oid.addToSequence("listtest",100,new Integer(100));
+                   oid.putIntoSequence("listtest",99,new Integer(99));
+                   oid.removeFromSet("settest",new Integer(1));
+                   oid.removeFromSet("multisettest",new Integer(2));
+                   oid.removeFromSequence("listtest",99);
+                   oid.removeFromSequence("listtest",1);
                }
                con.commit();
                rs.close();
@@ -1311,7 +1311,7 @@ CUBRIDDataSource에 대한 자세한 설명은 :ref:`jdbc-conn-datasource`\ 을 
                stmt = conn.createStatement();
                stmt.executeUpdate("CREATE TABLE xoo ( a INT, b INT, c CHAR(10))");
      
-               preStmt = conn.prepareStatement("INSERT INTO xoo VALUES(?,?,'100')");
+               preStmt = conn.prepareStatement("INSERT INTO xoo VALUES(?,?,''''100'''')");
                preStmt.setInt (1, 1) ;
                preStmt.setInt (2, 1*10) ;
                int rst = preStmt.executeUpdate () ;

--- a/ko/api/python.rst
+++ b/ko/api/python.rst
@@ -51,7 +51,7 @@ Linux, Unix 및 유사 운영체제에서는 다음과 같은 세 가지 방법�
 
 **Easy Install을 이용한 설치(Linux)**
 
-Easy Install은 자동으로 Python 패키지를 다운로드/빌드/설치/관리할 수 있는 Python 모듈로, setuptools에 포함되어 있다. Easy Install을 사용하면 패키지 인덱스뿐만 아니라 다른 웹 사이트에도 HTTP로 연결하여 패키지를 설치할 수 있다. Perl의 CPAN이나 PHP의 PEAR와 유사하다. Easy Install에 대한 더 자세한 설명은 https://setuptools.readthedocs.io/en/latest/deprecated/easy_install.html\ 을 참고한다.
+Easy Install은 자동으로 Python 패키지를 다운로드/빌드/설치/관리할 수 있는 Python 모듈로, setuptools에 포함되어 있다. Easy Install을 사용하면 패키지 인덱스뿐만 아니라 다른 웹 사이트에도 HTTP로 연결하여 패키지를 설치할 수 있다. Perl의 CPAN이나 PHP의 PEAR와 유사하다. Easy Install에 대한 더 자세한 설명은 https://setuptools.readthedocs.io/en/latest/easy_install.html\ 을 참고한다.
 
 Easy Install을 이용하여 CUBRID Python 드라이버를 설치하려면 다음 명령어를 입력한다. ::
 


### PR DESCRIPTION
Reverts CUBRID/cubrid-manual#197 in order to exclude python.rst, other things are not changed.
So this PR will be deleted.