### PR TITLE
[CUBRIDMAN-11] Adding a configuration parameter to allow truncated string.

### DIFF
--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -1224,11 +1224,11 @@ The following are parameters related to SQL statements and data types supported 
 
 **alter_table_change_type_strict**
 
-    **alter_table_change_type_strict** is a parameter to configure whether or not to allow the conversion of column values according to the type change, and the default value is **yes**. If a value for this parameter is set to **no**, the value may be changed when you change the column types or when you add **NOT NULL** constraints; if it is set to **yes**, the value is not changed. For details, see CHANGE Clause in the :ref:`change-column`.
+    **alter_table_change_type_strict** is a parameter to configure whether to allow the conversion of column values according to the type change, and the default value is **yes**. If a value for this parameter is set to **no**, the value may be changed when you change the column types or when you add **NOT NULL** constraints; if it is set to **yes**, the value does not change. For details, see CHANGE Clause in the :ref:`change-column`.
 
 **allow_truncated_string**
 
-    **allow_truncated_string** is a parameter to configure whether or not to allow the truncation of string values according to any string operations, and the default value is **no**. If a value for this parameter is set to **no**, the string value may be truncated when you do operation for any string related on insert or update query but the string related on select query may be truncated regardless of this configuration. If it is set to **yes**, the string value may be truncated regardless of the type of (insert/update/select) query.
+    **allow_truncated_string** is a parameter to configure whether to allow the truncation of string values according to the string manipulation operations used in insert or update query, and the default value is **no**. If the value for this parameter is set to **no**, the string value not allow to be truncated when you do operation for any string related to insert or update query; however the string related to select query may be truncated regardless of this configuration. If it is set to **yes**, the string value may be truncated regardless of the type of (insert/update/select) query.
 
 **ansi_quotes**
 

--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -1228,7 +1228,7 @@ The following are parameters related to SQL statements and data types supported 
 
 **allow_truncated_string**
 
-    **allow_truncated_string** is a parameter to configure whether to allow the truncation of string values according to the string manipulation operations used in insert or update query, and the default value is **no**. If the value for this parameter is set to **no**, the string value is not allow to be truncated when you do operation for any string related to insert or update query; however the string related to select query may be truncated regardless of this configuration. If it is set to **yes**, the string value may be truncated regardless of the type of (insert/update/select) query.
+    **allow_truncated_string** is a parameter to configure whether to allow the truncation of string values according to the string manipulation operations used in insert or update query, and the default value is **no**. If the value for this parameter is set to **no**, the string value is not allowed to be truncated when you do operation for any string related to insert or update query; however the string related to select query may be truncated regardless of this configuration. If it is set to **yes**, the string value may be truncated regardless of the type of (INSERT/UPDATE/SELECT) query.
 
 **ansi_quotes**
 

--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -221,7 +221,9 @@ On the below table, if "Applied" is "server parameter", that parameter affects t
 +-------------------------------+-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
 | :ref:`stmt-type-parameters`   | add_column_update_hard_default      | client/server parameter | O       | bool     | no                             | available             |
 |                               +-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
-|                               | alter_table_change_type_strict      | client/server parameter | O       | bool     | no                             | available             |
+|                               | alter_table_change_type_strict      | client/server parameter | O       | bool     | yes                             | available             |
+|                               +-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
+|                               | allow_truncated_string              | client/server parameter | O       | bool     | no                             | available             |
 |                               +-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
 |                               | ansi_quotes                         | client parameter        |         | bool     | yes                            |                       |
 |                               +-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
@@ -1134,7 +1136,9 @@ The following are parameters related to SQL statements and data types supported 
 +=================================+========+============+============+============+
 | add_column_update_hard_default  | bool   | no         |            |            |
 +---------------------------------+--------+------------+------------+------------+
-| alter_table_change_type_strict  | bool   | no         |            |            |
+| alter_table_change_type_strict  | bool   | yes        |            |            |
++---------------------------------+--------+------------+------------+------------+
+| allow_truncated_string          | bool   | no         |            |            |
 +---------------------------------+--------+------------+------------+------------+
 | ansi_quotes                     | bool   | yes        |            |            |
 +---------------------------------+--------+------------+------------+------------+
@@ -1220,7 +1224,11 @@ The following are parameters related to SQL statements and data types supported 
 
 **alter_table_change_type_strict**
 
-    **alter_table_change_type_strict** is a parameter to configure whether or not to allow the conversion of column values according to the type change, and the default value is **no**. If a value for this parameter is set to **no**, the value may be changed when you change the column types or when you add **NOT NULL** constraints; if it is set to **yes**, the value is not changed. For details, see CHANGE Clause in the :ref:`change-column`.
+    **alter_table_change_type_strict** is a parameter to configure whether or not to allow the conversion of column values according to the type change, and the default value is **yes**. If a value for this parameter is set to **no**, the value may be changed when you change the column types or when you add **NOT NULL** constraints; if it is set to **yes**, the value is not changed. For details, see CHANGE Clause in the :ref:`change-column`.
+
+**allow_truncated_string**
+
+    **allow_truncated_string** is a parameter to configure whether or not to allow the truncation of string values according to any string operations, and the default value is **no**. If a value for this parameter is set to **no**, the string value may be truncated when you do operation for any string related on insert or update query but the string related on select query may be truncated regardless of this configuration. If it is set to **yes**, the string value may be truncated regardless of the type of (insert/update/select) query.
 
 **ansi_quotes**
 

--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -1228,7 +1228,7 @@ The following are parameters related to SQL statements and data types supported 
 
 **allow_truncated_string**
 
-    **allow_truncated_string** is a parameter to configure whether to allow the truncation of string values according to the string manipulation operations used in insert or update query, and the default value is **no**. If the value for this parameter is set to **no**, the string value not allow to be truncated when you do operation for any string related to insert or update query; however the string related to select query may be truncated regardless of this configuration. If it is set to **yes**, the string value may be truncated regardless of the type of (insert/update/select) query.
+    **allow_truncated_string** is a parameter to configure whether to allow the truncation of string values according to the string manipulation operations used in insert or update query, and the default value is **no**. If the value for this parameter is set to **no**, the string value is not allow to be truncated when you do operation for any string related to insert or update query; however the string related to select query may be truncated regardless of this configuration. If it is set to **yes**, the string value may be truncated regardless of the type of (insert/update/select) query.
 
 **ansi_quotes**
 

--- a/en/sql/datatype.rst
+++ b/en/sql/datatype.rst
@@ -1103,7 +1103,7 @@ The following are the rules that are applied when using the character string typ
 
     Specify the number of a character string.
 
-    When the length of the character string entered exceeds the length specified, the excess characters may be truncated on the insert/update operation if the allow_truncated_string configuration value is "yes" or error occurs if not.
+    When the length of the character string entered exceeds the length specified, the excess characters may be truncated in the insert/update operation if the allow_truncated_string configuration value is "yes" otherwise error occurs.
 
     For a fixed-length character string type such as **CHAR**, the length is fixed at the declared length. Therefore, the right part (trailing space) of the character string is filled with space characters when the string is stored. For a variable-length character string type such as **VARCHAR**, only the entered character string is stored, and the space is not filled with space characters.
 
@@ -1141,7 +1141,7 @@ CHAR(n)
 
 A fixed-length character string is represented as **CHAR** *(n)*, in which *n* represents the number of characters. If *n* is not specified, the value is specified as 1, default value.
 
-When the length of a character string exceeds *n*, they may be truncated on the insert/update operation if the allow_truncated_string configuration value is "yes" or error occurs if not. When character string which is shorter than *n* is stored, whitespace characters are used to fill up the trailing space.
+When the length of a character string exceeds *n*, they may be truncated in the insert/update operation if the allow_truncated_string configuration value is "yes" otherwise error occurs. When character string which is shorter than *n* is stored, white space characters are used to fill up the trailing space.
 
 **CHAR** (*n*) and **CHARACTER** (*n*) are used interchangeably.
 
@@ -1155,8 +1155,8 @@ When the length of a character string exceeds *n*, they may be truncated on the 
 
 ::
 
-    If you specify 'pacesetter' as CHAR(12), 'pacesetter ' is stored (a 10-character string plus two whitespace characters).
-    If you specify 'pacesetter ' as CHAR(10), 'pacesetter' is stored (a 10-character string; two whitespace characters are truncated).
+    If you specify 'pacesetter' as CHAR(12), 'pacesetter ' is stored (a 10-character string plus two white space characters).
+    If you specify 'pacesetter ' as CHAR(10), 'pacesetter' is stored (a 10-character string; two white space characters are truncated).
     If you specify 'pacesetter' as CHAR(4), 'pace' may be stored or error occurs depending on the configuration value of allow_truncated_string (truncated as the length of the character string is greater than 4).
     If you specify 'p ' as CHAR, 'p' is stored (if n is not specified, the length is set to the default value 1).
 
@@ -1167,7 +1167,7 @@ VARCHAR(n)/CHAR VARYING(n)
 
 Variable-length character strings are represented as **VARCHAR** (*n*), where *n* represents the number of characters. If *n* is not specified, the value is specified as 1,073,741,823, the maximum length.
 
-When the length of a character string exceeds *n*, they may be truncated on the insert/update operation if the allow_truncated_string configuration value is **yes** or error occurs if not.  When character string which is shorter than *n* is stored, for **VARCHAR** (*n*), the length of string used are stored without any trailing spaces.
+When the length of a character string exceeds *n*, they may be truncated in the insert/update operation if the allow_truncated_string configuration value is **yes** or error occurs if not.  When character string which is shorter than *n* is stored, for **VARCHAR** (*n*), the length of string used are stored without any trailing spaces.
 
 **VARCHAR** (*n*), **CHARACTER, VARYING** (*n*), and **CHAR VARYING** (*n*) are used interchangeably.
 
@@ -1182,8 +1182,8 @@ When the length of a character string exceeds *n*, they may be truncated on the 
     If you specify 'pacesetter' as VARCHAR(4), 'pace' may be stored or error occurs depending on the configuration value of allow_truncated_string (truncated as the length of the character string is greater than 4).
     If you specify 'pacesetter' as VARCHAR(12), 'pacesetter' is stored (a 10-character string).
     If you specify 'pacesetter ' as VARCHAR(12), 'pacesetter ' is stored (a 11-character string).
-    If you specify 'pacesetter ' as VARCHAR(10), 'pacesetter' may be stored or error occurs depending on the configuration value of allow_truncated_string (a 10-character string; two whitespace characters can be truncated).
-    If you specify 'p ' as VARCHAR, 'p ' is stored (if n is not specified, the default value 1,073,741,823 is used, and the trailing space is not filled with whitespace characters)`
+    If you specify 'pacesetter ' as VARCHAR(10), 'pacesetter' may be stored or error occurs depending on the configuration value of allow_truncated_string (a 10-character string; two white space characters can be truncated).
+    If you specify 'p ' as VARCHAR, 'p ' is stored (if n is not specified, the default value 1,073,741,823 is used, and the trailing space is not filled with white space characters).
 
 *   **DEFAULT** constraint can be specified in a column of this type.
 

--- a/en/sql/datatype.rst
+++ b/en/sql/datatype.rst
@@ -1157,7 +1157,7 @@ When the length of a character string exceeds *n*, they may be truncated on the 
 
     If you specify 'pacesetter' as CHAR(12), 'pacesetter ' is stored (a 10-character string plus two whitespace characters).
     If you specify 'pacesetter ' as CHAR(10), 'pacesetter' is stored (a 10-character string; two whitespace characters are truncated).
-    If you specify 'pacesetter' as CHAR(4), 'pace' may be stored or error occurs at the configuration value of allow_truncated_string (truncated as the length of the character string is greater than 4).
+    If you specify 'pacesetter' as CHAR(4), 'pace' may be stored or error occurs depending on the configuration value of allow_truncated_string (truncated as the length of the character string is greater than 4).
     If you specify 'p ' as CHAR, 'p' is stored (if n is not specified, the length is set to the default value 1).
 
 *   **DEFAULT** constraint can be specified in a column of this type.
@@ -1167,7 +1167,7 @@ VARCHAR(n)/CHAR VARYING(n)
 
 Variable-length character strings are represented as **VARCHAR** (*n*), where *n* represents the number of characters. If *n* is not specified, the value is specified as 1,073,741,823, the maximum length.
 
-When the length of a character string exceeds *n*, they may be truncated on the insert/update operation if the allow_truncated_string   configuration value is "yes" or error occurs if not.  When character string which is shorter than *n* is stored, for **VARCHAR** (*n*), the length of string used are stored without any trailing spaces.
+When the length of a character string exceeds *n*, they may be truncated on the insert/update operation if the allow_truncated_string configuration value is **yes** or error occurs if not.  When character string which is shorter than *n* is stored, for **VARCHAR** (*n*), the length of string used are stored without any trailing spaces.
 
 **VARCHAR** (*n*), **CHARACTER, VARYING** (*n*), and **CHAR VARYING** (*n*) are used interchangeably.
 
@@ -1179,11 +1179,11 @@ When the length of a character string exceeds *n*, they may be truncated on the 
 
 ::
 
-    If you specify 'pacesetter' as CHAR(4), 'pace' may be stored or error occurs at the configuration value of allow_truncated_string (truncated as the length of the character string is greater than 4).
+    If you specify 'pacesetter' as CHAR(4), 'pace' may be stored or error occurs depending on the configuration value of allow_truncated_string (truncated as the length of the character string is greater than 4).
     If you specify 'pacesetter' as VARCHAR(12), 'pacesetter' is stored (a 10-character string).
     If you specify 'pacesetter ' as VARCHAR(12), 'pacesetter ' is stored (a 10-character string plus two whitespace characters).
     If you specify 'pacesetter ' as VARCHAR(10), 'pacesetter' is stored (a 10-character string; two whitespace characters can be truncated as above example).
-    If you specify 'p ' as VARCHAR, 'p' is stored (if n is not specified, the default value 1,073,741,823 is used, and the trailing space is not filled with whitespace characters).
+    If you specify 'p ' as VARCHAR, 'p ' is stored (if n is not specified, the default value 1,073,741,823 is used, and the trailing space is not filled with whitespace characters).
 
 *   **DEFAULT** constraint can be specified in a column of this type.
 

--- a/en/sql/datatype.rst
+++ b/en/sql/datatype.rst
@@ -1179,11 +1179,11 @@ When the length of a character string exceeds *n*, they may be truncated on the 
 
 ::
 
-    If you specify 'pacesetter' as CHAR(4), 'pace' may be stored or error occurs depending on the configuration value of allow_truncated_string (truncated as the length of the character string is greater than 4).
+    If you specify 'pacesetter' as VARCHAR(4), 'pace' may be stored or error occurs depending on the configuration value of allow_truncated_string (truncated as the length of the character string is greater than 4).
     If you specify 'pacesetter' as VARCHAR(12), 'pacesetter' is stored (a 10-character string).
-    If you specify 'pacesetter ' as VARCHAR(12), 'pacesetter ' is stored (a 10-character string plus two whitespace characters).
-    If you specify 'pacesetter ' as VARCHAR(10), 'pacesetter' is stored (a 10-character string; two whitespace characters can be truncated as above example).
-    If you specify 'p ' as VARCHAR, 'p ' is stored (if n is not specified, the default value 1,073,741,823 is used, and the trailing space is not filled with whitespace characters).
+    If you specify 'pacesetter ' as VARCHAR(12), 'pacesetter ' is stored (a 12-character string).
+    If you specify 'pacesetter ' as VARCHAR(10), 'pacesetter' may be stored or error occurs depending on the configuration value of allow_truncated_string (a 10-character string; two whitespace characters can be truncated).
+    If you specify 'p ' as VARCHAR, 'p ' is stored (if n is not specified, the default value 1,073,741,823 is used, and the trailing space is not filled with whitespace characters)`
 
 *   **DEFAULT** constraint can be specified in a column of this type.
 

--- a/en/sql/datatype.rst
+++ b/en/sql/datatype.rst
@@ -1181,7 +1181,7 @@ When the length of a character string exceeds *n*, they may be truncated on the 
 
     If you specify 'pacesetter' as VARCHAR(4), 'pace' may be stored or error occurs depending on the configuration value of allow_truncated_string (truncated as the length of the character string is greater than 4).
     If you specify 'pacesetter' as VARCHAR(12), 'pacesetter' is stored (a 10-character string).
-    If you specify 'pacesetter ' as VARCHAR(12), 'pacesetter ' is stored (a 12-character string).
+    If you specify 'pacesetter ' as VARCHAR(12), 'pacesetter ' is stored (a 11-character string).
     If you specify 'pacesetter ' as VARCHAR(10), 'pacesetter' may be stored or error occurs depending on the configuration value of allow_truncated_string (a 10-character string; two whitespace characters can be truncated).
     If you specify 'p ' as VARCHAR, 'p ' is stored (if n is not specified, the default value 1,073,741,823 is used, and the trailing space is not filled with whitespace characters)`
 

--- a/en/sql/datatype.rst
+++ b/en/sql/datatype.rst
@@ -1103,7 +1103,7 @@ The following are the rules that are applied when using the character string typ
 
     Specify the number of a character string.
 
-    When the length of the character string entered exceeds the length specified, the excess characters are truncated.
+    When the length of the character string entered exceeds the length specified, the excess characters may be truncated on the insert/update operation if the allow_truncated_string configuration value is "yes" or error occurs if not.
 
     For a fixed-length character string type such as **CHAR**, the length is fixed at the declared length. Therefore, the right part (trailing space) of the character string is filled with space characters when the string is stored. For a variable-length character string type such as **VARCHAR**, only the entered character string is stored, and the space is not filled with space characters.
 
@@ -1141,7 +1141,7 @@ CHAR(n)
 
 A fixed-length character string is represented as **CHAR** *(n)*, in which *n* represents the number of characters. If *n* is not specified, the value is specified as 1, default value.
 
-When the length of a character string exceeds *n*, they are truncated. When character string which is shorter than *n* is stored, whitespace characters are used to fill up the trailing space.
+When the length of a character string exceeds *n*, they may be truncated on the insert/update operation if the allow_truncated_string configuration value is "yes" or error occurs if not. When character string which is shorter than *n* is stored, whitespace characters are used to fill up the trailing space.
 
 **CHAR** (*n*) and **CHARACTER** (*n*) are used interchangeably.
 
@@ -1157,7 +1157,7 @@ When the length of a character string exceeds *n*, they are truncated. When char
 
     If you specify 'pacesetter' as CHAR(12), 'pacesetter ' is stored (a 10-character string plus two whitespace characters).
     If you specify 'pacesetter ' as CHAR(10), 'pacesetter' is stored (a 10-character string; two whitespace characters are truncated).
-    If you specify 'pacesetter' as CHAR(4), 'pace' is stored (truncated as the length of the character string is greater than 4).
+    If you specify 'pacesetter' as CHAR(4), 'pace' may be stored or error occurs at the configuration value of allow_truncated_string (truncated as the length of the character string is greater than 4).
     If you specify 'p ' as CHAR, 'p' is stored (if n is not specified, the length is set to the default value 1).
 
 *   **DEFAULT** constraint can be specified in a column of this type.
@@ -1167,7 +1167,7 @@ VARCHAR(n)/CHAR VARYING(n)
 
 Variable-length character strings are represented as **VARCHAR** (*n*), where *n* represents the number of characters. If *n* is not specified, the value is specified as 1,073,741,823, the maximum length.
 
-When the length of a character string exceeds *n*, they are truncated. When character string which is shorter than *n* is stored, whitespace characters are used to fill up the trailing space for **VARCHAR** (*n*), the length of string used are stored. 
+When the length of a character string exceeds *n*, they may be truncated on the insert/update operation if the allow_truncated_string   configuration value is "yes" or error occurs if not.  When character string which is shorter than *n* is stored, for **VARCHAR** (*n*), the length of string used are stored without any trailing spaces.
 
 **VARCHAR** (*n*), **CHARACTER, VARYING** (*n*), and **CHAR VARYING** (*n*) are used interchangeably.
 
@@ -1179,10 +1179,10 @@ When the length of a character string exceeds *n*, they are truncated. When char
 
 ::
 
-    If you specify 'pacesetter' as CHAR(4), 'pace' is stored (truncated as the length of the character string is greater than 4).
+    If you specify 'pacesetter' as CHAR(4), 'pace' may be stored or error occurs at the configuration value of allow_truncated_string (truncated as the length of the character string is greater than 4).
     If you specify 'pacesetter' as VARCHAR(12), 'pacesetter' is stored (a 10-character string).
     If you specify 'pacesetter ' as VARCHAR(12), 'pacesetter ' is stored (a 10-character string plus two whitespace characters).
-    If you specify 'pacesetter ' as VARCHAR(10), 'pacesetter' is stored (a 10-character string; two whitespace characters are truncated).
+    If you specify 'pacesetter ' as VARCHAR(10), 'pacesetter' is stored (a 10-character string; two whitespace characters can be truncated as above example).
     If you specify 'p ' as VARCHAR, 'p' is stored (if n is not specified, the default value 1,073,741,823 is used, and the trailing space is not filled with whitespace characters).
 
 *   **DEFAULT** constraint can be specified in a column of this type.

--- a/en/sql/schema/table_stmt.rst
+++ b/en/sql/schema/table_stmt.rst
@@ -1607,7 +1607,7 @@ The **alter_table_change_type_strict** parameter determines whether the value co
 
 When the value of the parameter, **alter_table_change_type_strict** is no, it will operate depending on the conditions as follows:
 
-*   Overflow occurred while converting numbers or character strings to Numbers: It is determined based on symbol of the result type. If it is negative value, it is specified as a minimum value or positive value, specified as the maximum value and a warning message for records where overflow occurred is recorded in the log. For strings, it will follow the rules stated above after it is converted to **DOUBLE** type. Overflow also can be returned by the parameter **allow_truncated_string** setting to **no** if the converted string is not to fit the length of the target string type.
+*   Overflow occurred while converting numbers or character strings to Numbers: It is determined based on symbol of the result type. If it is negative value, it is specified as a minimum value or positive value, specified as the maximum value and a warning message for records where overflow occurred is recorded in the log. For strings, it will follow the rules stated above after it is converted to **DOUBLE** type. Overflow can also be returned by the parameter **allow_truncated_string** setting to **no** if the converted string does not fit the length of the target string type.
 
 *   Character strings to convert to shorter ones: The record will be updated to the hard default value of the type that is defined and the warning message will be recorded in a log. Converting to shorter ones is not allowed when the **allow_truncated_string** is set to **no**.
 

--- a/en/sql/schema/table_stmt.rst
+++ b/en/sql/schema/table_stmt.rst
@@ -1362,7 +1362,8 @@ The **MODIFY** clause can modify type, size, and attribute of a column but canno
 
 If you set the type, size, and attribute to apply to a new column with the **CHANGE** clause or the **MODIFY** clause, the attribute that is currently defined will not be passed to the attribute of the new column.
 
-When you change data types using the **CHANGE** clause or the **MODIFY** clause, the data can be modified. For example, if you shorten the length of a column, the character string may be truncated.
+When you change data types using the **CHANGE** clause or the **MODIFY** clause, the data can be modified. For example, if you shorten the length of a column, the character string may be truncated if the value of configuration parameter alter_table_change_type_strict is set to **no**. But if the parameter value is set to **yes**, the change or modify is not allowed and it returns an error.
+the configuration parameter allow_truncated_string also affect the similar as alter_table_change_type_strict.
 
 .. warning::
 
@@ -1606,13 +1607,13 @@ The **alter_table_change_type_strict** parameter determines whether the value co
 
 When the value of the parameter, **alter_table_change_type_strict** is no, it will operate depending on the conditions as follows:
 
-*   Overflow occurred while converting numbers or character strings to Numbers: It is determined based on symbol of the result type. If it is negative value, it is specified as a minimum value or positive value, specified as the maximum value and a warning message for records where overflow occurred is recorded in the log. For strings, it will follow the rules stated above after it is converted to **DOUBLE** type.
+*   Overflow occurred while converting numbers or character strings to Numbers: It is determined based on symbol of the result type. If it is negative value, it is specified as a minimum value or positive value, specified as the maximum value and a warning message for records where overflow occurred is recorded in the log. For strings, it will follow the rules stated above after it is converted to **DOUBLE** type. Overflow also can be returned by the parameter **allow_truncated_string** setting to **no** if the converted string is not to fit the length of the target string type.
 
-*   Character strings to convert to shorter ones: The record will be updated to the hard default value of the type that is defined and the warning message will be recorded in a log.
+*   Character strings to convert to shorter ones: The record will be updated to the hard default value of the type that is defined and the warning message will be recorded in a log. Converting to shorter ones is not allowed when the **allow_truncated_string** is set to **no**.
 
 *   Conversion failure due to other reasons: The record will be updated to the hard default value of the type that is defined and the warning message will be recorded in a log.
 
-If the value of the **alter_table_change_type_strict** parameter is yes, an error message will be displayed and the changes will be rolled back.
+If the value of the **alter_table_change_type_strict** parameter is yes or **allow_truncated_string** is set to no, an error message will be displayed and the changes will be rolled back.
 
 The **ALTER CHANGE** statement checks the possibility of type conversion before updating a record but the type conversion of specific values may fail. For example, if the value format is not correct when you convert **VARCHAR** to **DATE**, the conversion may fail. In this case, the hard default value of the **DATE** type will be assigned.
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-11

We need to a configuration parameter to allow truncated string as like the issue http://jira.cubrid.org/browse/CBRD-23679
The added parameter is named as "ALLOW_TRUNCATED_STRING".