### PR TITLE
[CUBRIDMAN-12] In data comparing, no ignoring to trailing spaces at the end of the data.

### DIFF
--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -268,8 +268,6 @@ On the below table, if "Applied" is "server parameter", that parameter affects t
 |                               | unicode_output_normalization        | client parameter        | O       | bool     | no                             | available             |
 |                               +-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
 |                               | update_use_attribute_references     | client parameter        | O       | bool     | no                             | available             |
-|                               +-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
-|                               | ignore_trailing_space               | server parameter        |         | bool     | no                             |               |
 +-------------------------------+-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
 | :ref:`thread-parameters`      | thread_connection_pooling           | server parameter        |         | bool     | yes                            |                       |
 |                               +-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
@@ -1184,8 +1182,6 @@ The following are parameters related to SQL statements and data types supported 
 +---------------------------------+--------+------------+------------+------------+
 | update_use_attribute_references | bool   | no         |            |            |
 +---------------------------------+--------+------------+------------+------------+
-| ignore_trailing_space           | bool   | no         |            |            |
-+---------------------------------+--------+------------+------------+------------+
 
 **add_column_update_hard_default**
 
@@ -1653,15 +1649,6 @@ The following are parameters related to SQL statements and data types supported 
     ::
       
         1, NULL
-
-**ignore_trailing_space**
-
-If this parameter's value is **yes**, the string comparison follows "trailing space insensitive" rules as below example.
-The string value 'abc' and 'abc ' is equal regardless the types of values are VARCHAR-type with variable length.
-
-**CAUTION:**
-
-Do not change this parameter value or it will result in confusion at several parts of using the data. Especially, for the table with primary key or unique key using string type, the data integrity may not be preserved by changing this parameter value. For example, data with unique key constraint at **"no ignore trailing space"** configuration might violate this constraint at **"ignore trailing space"** because the key value 'abc  'and 'abc ' is equal at changed configuration. Therefore, this configuration value change should be considered seriously. CUBRID recommends that the value of this parameter is fixed and not to change for all life times in the database.
 
 .. _thread-parameters:
 

--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -268,6 +268,8 @@ On the below table, if "Applied" is "server parameter", that parameter affects t
 |                               | unicode_output_normalization        | client parameter        | O       | bool     | no                             | available             |
 |                               +-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
 |                               | update_use_attribute_references     | client parameter        | O       | bool     | no                             | available             |
+|                               +-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
+|                               | ignore_trailing_space               | server parameter        |         | bool     | no                             |               |
 +-------------------------------+-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
 | :ref:`thread-parameters`      | thread_connection_pooling           | server parameter        |         | bool     | yes                            |                       |
 |                               +-------------------------------------+-------------------------+---------+----------+--------------------------------+-----------------------+
@@ -1182,6 +1184,8 @@ The following are parameters related to SQL statements and data types supported 
 +---------------------------------+--------+------------+------------+------------+
 | update_use_attribute_references | bool   | no         |            |            |
 +---------------------------------+--------+------------+------------+------------+
+| ignore_trailing_space           | bool   | no         |            |            |
++---------------------------------+--------+------------+------------+------------+
 
 **add_column_update_hard_default**
 
@@ -1649,6 +1653,14 @@ The following are parameters related to SQL statements and data types supported 
     ::
       
         1, NULL
+
+**ignore_trailing_space**
+
+If this parameter's value is **yes**, the string comparsion follows "trailing space insensitive" rules as below examle.
+The string value 'abc' and 'abc ' is equal regardless the types of values are VARCHAR-type with variable length.
+
+**CAUTION:**
+For the string data stored as "ignore_trailing_space" is set to **no** or **yes**, it will result to confuse at several parts of using the data when the configuration parameter value is changed to set to **yes** or **no**. Threfore, this configuration value change should be considered seriously. CUBRID recommends that the value of this parameter be fixed not to change for all life times in the database.
 
 .. _thread-parameters:
 

--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -1660,7 +1660,8 @@ If this parameter's value is **yes**, the string comparison follows "trailing sp
 The string value 'abc' and 'abc ' is equal regardless the types of values are VARCHAR-type with variable length.
 
 **CAUTION:**
-For the string data stored as **ignore_trailing_space** is set to **no** or **yes**; will result in confusion at several parts of using the data when the configuration parameter value is changed to set to **yes** or **no**. Therefore, this configuration value change should be considered seriously. CUBRID recommends that the value of this parameter is fixed and not to change for all life times in the database.
+
+Do not change this parameter value or it will result in confusion at several parts of using the data. Especially, for the table with primary key or unique key using string type, the data integrity may not be preserved by changing this parameter value. For example, data with unique key constraint at **"no ignore trailing space"** configuration might violate this constraint at **"ignore trailing space"** because the key value 'abc  'and 'abc ' is equal at changed configuration. Therefore, this configuration value change should be considered seriously. CUBRID recommends that the value of this parameter is fixed and not to change for all life times in the database.
 
 .. _thread-parameters:
 

--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -1660,7 +1660,7 @@ If this parameter's value is **yes**, the string comparsion follows "trailing sp
 The string value 'abc' and 'abc ' is equal regardless the types of values are VARCHAR-type with variable length.
 
 **CAUTION:**
-For the string data stored as "ignore_trailing_space" is set to **no** or **yes**, it will result to confuse at several parts of using the data when the configuration parameter value is changed to set to **yes** or **no**. Threfore, this configuration value change should be considered seriously. CUBRID recommends that the value of this parameter be fixed not to change for all life times in the database.
+For the string data stored as "ignore_trailing_space" is set to **no** or **yes**, it will result to confuse at several parts of using the data when the configuration parameter value is changed to set to **yes** or **no**. Therefore, this configuration value change should be considered seriously. CUBRID recommends that the value of this parameter is fixed not to change for all life times in the database.
 
 .. _thread-parameters:
 

--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -1656,11 +1656,11 @@ The following are parameters related to SQL statements and data types supported 
 
 **ignore_trailing_space**
 
-If this parameter's value is **yes**, the string comparsion follows "trailing space insensitive" rules as below examle.
+If this parameter's value is **yes**, the string comparison follows "trailing space insensitive" rules as below example.
 The string value 'abc' and 'abc ' is equal regardless the types of values are VARCHAR-type with variable length.
 
 **CAUTION:**
-For the string data stored as "ignore_trailing_space" is set to **no** or **yes**, it will result to confuse at several parts of using the data when the configuration parameter value is changed to set to **yes** or **no**. Therefore, this configuration value change should be considered seriously. CUBRID recommends that the value of this parameter is fixed not to change for all life times in the database.
+For the string data stored as **ignore_trailing_space** is set to **no** or **yes**; will result in confusion at several parts of using the data when the configuration parameter value is changed to set to **yes** or **no**. Therefore, this configuration value change should be considered seriously. CUBRID recommends that the value of this parameter is fixed and not to change for all life times in the database.
 
 .. _thread-parameters:
 

--- a/en/sql/datatype.rst
+++ b/en/sql/datatype.rst
@@ -1337,25 +1337,25 @@ If you want use other character than a backslash as an escape character, you can
 Comparison Rules
 ----------------
 
-The string values having CHAR-type or VARCAHR-type are compared using one of the two comparison rules as follows:
+When two string values are compared, the followings are the comparison rules about the behavior of trailing spaces:
 
 *   Comparison for trailing space insensitive
 *   Comparison for trailing space sensitive
 
 **Trailing space insensitive**
 
-If the two string values have fixed length like CHAR-type, the comparison ignores trailing spaces as below example.
+If the two string values are both fixed-length types (CHAR-type), the comparison ignores trailing spaces as below example.
 comparing 'abc ' with 'abc   ' results equal
 
 **Trailing space sensitive**
 
-If the two string values have variable length like VARCHAR-type, the comparison does not ignore trailing spaces as below example.
+If two string values are both of variable-length types (VARCHAR-type), the comparison does not ignore trailing spaces as below example.
 comparing 'abc ' with 'abc   ' results 'abc   ' greater than 'abc '
 
 **Exceptions**
 
-If two string values have each length as fixed and variable, CUBRID follows "trailing space sensitive" rule
-If the configuration parameter value **ignore_trailing_space** is set to **yes**, CUBIRD follows "trailing space insensitive" rule regardless two string values have fixed or variable length.
+When comparing two string values, if one is a fixed-type and the other is a variable-type, CUBRID follows "trailing space sensitive" rule.
+If the configuration parameter value **ignore_trailing_space** is set to **yes**, CUBIRD follows "trailing space insensitive" rule regardless of the types of string values.
 
 ENUM Data Type
 ==============

--- a/en/sql/datatype.rst
+++ b/en/sql/datatype.rst
@@ -1355,7 +1355,6 @@ comparing 'abc ' with 'abc   ' results 'abc   ' greater than 'abc '
 **Exceptions**
 
 When comparing two string values, if one is a fixed-type and the other is a variable-type, CUBRID follows "trailing space sensitive" rule.
-If the configuration parameter value **ignore_trailing_space** is set to **yes**, CUBIRD follows "trailing space insensitive" rule regardless of the types of string values.
 
 ENUM Data Type
 ==============

--- a/en/sql/datatype.rst
+++ b/en/sql/datatype.rst
@@ -1352,7 +1352,10 @@ If the two string values have fixed length like CHAR-type, the comparison ignore
 If the two string values have variable length like VARCHAR-type, the comparison does not ignore trailing spaces as belows example.
 'abc ' < 'abc   ' results 'abc   ' greater than 'abc '
 
-If two string values have each length as fixed and variable, CUBRID follows "comparison for trailing sensitive" rule
+**Exceptions**
+
+If two string values have each length as fixed and variable, CUBRID follows "trailing space sensitive" rule
+If the configuration parameter value **ignore_trailing_space** is set to **yes**, CUBIRD follows "trailing space insensitive" rule regardless two string values have fixed or variable length.
 
 ENUM Data Type
 ==============

--- a/en/sql/datatype.rst
+++ b/en/sql/datatype.rst
@@ -1334,6 +1334,26 @@ If you want use other character than a backslash as an escape character, you can
 
     SELECT a FROM t1 WHERE a LIKE 'aaa#%' ESCAPE '#';
 
+Comparison Rules
+----------------
+
+The string values having CHAR-type or VARCAHR-type are compared using one of the two comparison rules as follows:
+
+*   Comparison for trailing space insensitive
+*   Comparison for trailing space sensitive
+
+**Trailing space insensitive**
+
+If the two string values have fixed length like CHAR-type, the comparison ignores trailing spaces as belows example.
+'abc ' = 'abc   ' results equal
+
+**Trailing space sensitive**
+
+If the two string values have variable length like VARCHAR-type, the comparison does not ignore trailing spaces as belows example.
+'abc ' < 'abc   ' results 'abc   ' greater than 'abc '
+
+If two string values have each length as fixed and variable, CUBRID follows "comparison for trailing sensitive" rule
+
 ENUM Data Type
 ==============
 

--- a/en/sql/datatype.rst
+++ b/en/sql/datatype.rst
@@ -1344,13 +1344,13 @@ The string values having CHAR-type or VARCAHR-type are compared using one of the
 
 **Trailing space insensitive**
 
-If the two string values have fixed length like CHAR-type, the comparison ignores trailing spaces as belows example.
-'abc ' = 'abc   ' results equal
+If the two string values have fixed length like CHAR-type, the comparison ignores trailing spaces as below example.
+comparing 'abc ' with 'abc   ' results equal
 
 **Trailing space sensitive**
 
-If the two string values have variable length like VARCHAR-type, the comparison does not ignore trailing spaces as belows example.
-'abc ' < 'abc   ' results 'abc   ' greater than 'abc '
+If the two string values have variable length like VARCHAR-type, the comparison does not ignore trailing spaces as below example.
+comparing 'abc ' with 'abc   ' results 'abc   ' greater than 'abc '
 
 **Exceptions**
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-12

In version 11.0, the trailing space is not ignored for the string data defined as string type except for fixed length char-type.
Refer to a related issue http://jira.cubrid.org/browse/CBRD-23731
We need to define a new configurable parameter "IGNORE_TRAILING_SPACE" for backward compatibility.
This parameter affect to the following sections:

- system parameter related
- schema (data type, string type related)
- string data manipulation related