### PR TITLE
[CUBRIDMAN-19] Fixed script in HA manual (Eng/Kor)

### DIFF
--- a/en/ha.rst
+++ b/en/ha.rst
@@ -3276,7 +3276,7 @@ Now let's see the case of rebuilding a existing slave node during a service in a
             
             repl_log_path=$repl_log_home_abs/${db_name}_${master_host}
 
-            local_db_creation=`awk 'BEGIN { print strftime("%m/%d/%Y %H:%M:%S", $db_creation) }'`
+            local_db_creation=`awk 'BEGIN { print strftime("%m/%d/%Y %H:%M:%S", '$db_creation') }'`
                 csql_cmd="\
                 INSERT INTO \
                         db_ha_apply_info \

--- a/ko/ha.rst
+++ b/ko/ha.rst
@@ -3273,7 +3273,7 @@ HA 서비스 운영 중 슬레이브를 새로 추가하려면 기존의 마스�
             
             repl_log_path=$repl_log_home_abs/${db_name}_${master_host}
 
-            local_db_creation=`awk 'BEGIN { print strftime("%m/%d/%Y %H:%M:%S", $db_creation) }'`
+            local_db_creation=`awk 'BEGIN { print strftime("%m/%d/%Y %H:%M:%S", '$db_creation') }'`
                 csql_cmd="\
                 INSERT INTO \
                         db_ha_apply_info \


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-19
In the script that inserts the information of db_ha_apply_info, $db_creation is recognized as a string, so a garbage value is inserted. It solved by '$db_creation'