### PR TITLE
[CUBRIDMAN-23] remove -u and -p option at tranlist and -p otion only work with -i or --kill option on killtran utility.

### DIFF
--- a/en/admin/admin_utils.rst
+++ b/en/admin/admin_utils.rst
@@ -2787,7 +2787,7 @@ When the object type is a class (table), *Nsubgranules* is displayed, which is t
 tranlist
 --------
 
-The **cubrid tranlist** is used to check the transaction information of the target database. Only DBA or DBA group can use this utility. ::
+The **cubrid tranlist** is used to check the transaction information of the target database. ::
 
     cubrid tranlist [options] database_name
 
@@ -2845,14 +2845,6 @@ The following shows [options] available with the **cubrid tranlist** utility.
 
 .. program:: tranlist
 
-.. option:: -u, --user=USER
-
-    *USER* is DB user's ID to log-in. It only allows DBA and DBA group users.(The default: DBA)
-    
-.. option:: -p, --password=PASSWORD
-
-    *PASSWORD* is DB user's password.
-    
 .. option:: -s, --summary
 
     This option outputs only summarized information(it omits query execution information or locking information).
@@ -2920,7 +2912,7 @@ The following shows [options] available with the **cubrid tranlist** utility.
 killtran
 --------
 
-The **cubrid killtran** is used to check transactions or abort specific transaction. Only a DBA can execute this utility. ::
+The **cubrid killtran** is used to check transactions or abort specific transaction. Only a **DBA** can use options for killing a transaction. ::
 
     cubrid killtran [options] database_name
 
@@ -2991,6 +2983,7 @@ The following shows [options] available with the **cubrid killtran** utility.
 
 .. option:: -p PASSWORD
 
+    This option can only be used, if using killing option such as -i and --kill options.
     A value followed by the -p option is a password of the **DBA**, and should be entered in the prompt.
 
 .. option:: -q, --query-exec-info

--- a/ko/admin/admin_utils.rst
+++ b/ko/admin/admin_utils.rst
@@ -2768,7 +2768,7 @@ lockdb
 tranlist
 --------
 
-**cubrid tranlist** 는 대상 데이터베이스의 트랜잭션 정보를 확인하는 유틸리티로서, DBA 또는 DBA그룹 사용자만 수행할 수 있다. ::
+**cubrid tranlist** 는 대상 데이터베이스의 트랜잭션 정보를 확인하는 유틸리티입니다. ::
 
     cubrid tranlist [options] database_name
 
@@ -2826,14 +2826,6 @@ tranlist
 
 .. program:: tranlist
 
-.. option:: -u, --user=USER
-
-    로그인할 사용자 ID. DBA및 DBA그룹 사용자만 허용한다.(기본값 : DBA)
-    
-.. option:: -p, --password=PASSWORD
-
-    사용자 비밀번호
-    
 .. option:: -s, --summary
 
     요약 정보만 출력한다(질의 수행 정보 또는 잠금 관련 정보를 생략).
@@ -2901,7 +2893,7 @@ tranlist
 killtran
 --------
 
-**cubrid killtran** 은 대상 데이터베이스의 트랜잭션을 확인하거나 특정 트랜잭션을 강제 종료하는 유틸리티로서, **DBA** 사용자만 수행할 수 있다. ::
+**cubrid killtran** 은 대상 데이터베이스의 트랜잭션을 확인하거나 특정 트랜잭션을 강제 종료하는 유틸리티로서, **DBA** 사용자만 트랜잭션을 제거할 수 있습니다. ::
 
     cubrid killtran [options] database_name
 
@@ -2972,6 +2964,7 @@ killtran
 
 .. option:: -p, --dba-password=PASSWORD
 
+    -i 또는 --kill 옵션들이 사용될 경우에만 해당 옵션을 사용할 수 있습니다.
     이 옵션 뒤에 오는 값은 **DBA** 의 암호이며 생략하면 프롬프트에서 입력해야 한다.
 
 .. option:: -q, --query-exec-info

--- a/ko/admin/admin_utils.rst
+++ b/ko/admin/admin_utils.rst
@@ -2768,7 +2768,7 @@ lockdb
 tranlist
 --------
 
-**cubrid tranlist** 는 대상 데이터베이스의 트랜잭션 정보를 확인하는 유틸리티입니다. ::
+**cubrid tranlist** 는 대상 데이터베이스의 트랜잭션 정보를 확인하는 유틸리티이다. ::
 
     cubrid tranlist [options] database_name
 
@@ -2893,7 +2893,7 @@ tranlist
 killtran
 --------
 
-**cubrid killtran** 은 대상 데이터베이스의 트랜잭션을 확인하거나 특정 트랜잭션을 강제 종료하는 유틸리티로서, **DBA** 사용자만 트랜잭션을 제거할 수 있습니다. ::
+**cubrid killtran** 은 대상 데이터베이스의 트랜잭션을 확인하거나 특정 트랜잭션을 강제 종료하는 유틸리티로서, **DBA** 사용자만 트랜잭션을 제거할 수 있다. ::
 
     cubrid killtran [options] database_name
 
@@ -2964,7 +2964,7 @@ killtran
 
 .. option:: -p, --dba-password=PASSWORD
 
-    -i 또는 --kill 옵션들이 사용될 경우에만 해당 옵션을 사용할 수 있습니다.
+    -i 또는 --kill 옵션들이 사용될 경우에만 해당 옵션을 사용할 수 있다.
     이 옵션 뒤에 오는 값은 **DBA** 의 암호이며 생략하면 프롬프트에서 입력해야 한다.
 
 .. option:: -q, --query-exec-info


### PR DESCRIPTION
1. tranlist
   - remove a statement related DBA.
   - remove -u, -p option with description.
2. killtran
   - change a statement related DBA.
   - add description to -p option.