### PR TITLE
[CUBRIDMAN-35] Add "db_ha_apply_info" to result of example in DB_CLASS

### DIFF
--- a/en/sql/catalog.rst
+++ b/en/sql/catalog.rst
@@ -1022,6 +1022,7 @@ The following example shows how to retrieve system classes that can be accessed 
     ======================
       'db_authorization'
       'db_authorizations'
+      'db_ha_apply_info'
       'db_root'
       'db_serial'
       'db_user'

--- a/ko/sql/catalog.rst
+++ b/ko/sql/catalog.rst
@@ -983,6 +983,7 @@ DB_CLASS
     ======================
       'db_authorization'
       'db_authorizations'
+      'db_ha_apply_info'
       'db_root'
       'db_serial'
       'db_user'


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-35

Add 'db_ha_apply_info' to the result of example in DB_CLASS because query result is different from the actual execution