### PR TITLE
[CUBRIDMAN-19] Fix wrong date literal format [Eng/Kor]

### DIFF
--- a/en/sql/literal.rst
+++ b/en/sql/literal.rst
@@ -45,7 +45,7 @@ However, the writing order of a string which indicates date or time.
 
     ::
     
-        date'1974-12-31', date'12-31-1974'
+        date'1974-12-31', date'12/31/1974'
 
 
 *   The time literal only allows 'HH:MI:SS', 'HH:MI:SS AM' or 'HH:MI:SS PM'.

--- a/ko/sql/literal.rst
+++ b/ko/sql/literal.rst
@@ -46,7 +46,7 @@ CUBRID에서 리터럴(literal) 값을 작성하는 방법을 기술한다.
 
     ::
     
-        date'1974-12-31', date'12-31-1974'
+        date'1974-12-31', date'12/31/1974'
 
 
 *   시간 리터럴은 'HH:MI:SS', 'HH:MI:SS AM', 'HH:MI:SS PM'만 허용한다.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-19
Only 'YYYY-MM-DD' or 'MM/DD/YYYY' is allowed as a date literal.
So, date'12-31-1974' has to be changed from '-' to '/'.