### PR TITLE
[CBRD-21446] Installing CUBRID with zip on Windows, cubrid server start fail. (english/korea)

### DIFF
--- a/en/install.rst
+++ b/en/install.rst
@@ -451,6 +451,12 @@ Check below list before installing CUBRID database of Windows version.
         
             %CUBRID%\bin
                 
+    .. note:: 
+
+        Setting environment variables for using CUBRID can be conveniently configured by using the batch file (cubrid_env.bat) below.
+        C:\CUBRID\shard\windows_scripts\cubrid_env.bat
+	
+	
     **Creating DB**
         
     *   Run **cmd** command and open the console; move to the directory to create DB and create DB.
@@ -547,3 +553,12 @@ Since CUBRID Service Tray is not automatically registered when installing CUBRID
     *   Check if CUBRID Service Tray is registered in [Start button] > [All Programs] > [Startup]; if not, register CUBRID Service Tray.
 
 For environment setting, tools installation and interfaces installation after CUBRID installation,  see :ref:`Installing-and-Running-on-Windows`.
+
+.. note:: 
+
+    If CUBRID is installed as a zip file, it may not be executed because there is no DLL required to execute CUBRID.
+    In this case, you need to install Microsoft Visual C++ Redistributable.
+    
+    *   **Microsoft Visual C++ Redistributable**
+    
+        https://visualstudio.microsoft.com/downloads/

--- a/ko/install.rst
+++ b/ko/install.rst
@@ -452,7 +452,13 @@ Windows 버전의 CUBRID 데이터베이스를 설치하기 전에 다음 사항
         ::
         
             %CUBRID%\bin
-                
+
+	.. note:: 
+	
+	    CUBRID를 사용하기 위한 환경변수 설정은 아래의 Batch file(cubrid_env.bat)을 이용하여 설정을 편리하게 할 수 있다.
+	    C:\\CUBRID\\shard\\windows_scripts\\cubrid_env.bat
+
+
     **DB 생성**
         
     *   cmd 명령으로 콘솔 창을 띄운 후 DB를 생성할 디렉터리로 이동해서 DB를 직접 생성한다.
@@ -549,3 +555,13 @@ zip 파일로 CUBRID를 설치하는 경우 CUBRID Service Tray가 자동으로 
     *   [시작 버튼] > [모든 프로그램] > [시작프로그램]에 CUBRID Service Tray가 등록되어 있는지 확인하고, 그렇지 않으면 CUBRID Service Tray를 등록한다.
 
 CUBRID 설치 이후 환경 설정, 도구 설치, 인터페이스 설치 등은 :ref:`Installing-and-Running-on-Windows`\을 확인하도록 한다.
+
+.. note:: 
+
+    zip 파일로 CUBRID를 설치한 경우, CUBRID 실행에 필요한 DLL 이 없어 실행이 되지 않을 수 있다.
+    이런 경우 Microsoft Visual C++ Redistributable 를 설치해야 한다.
+    
+    *   **Microsoft Visual C++ Redistributable**
+    
+        https://visualstudio.microsoft.com/ko/downloads/
+        


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-21446

When installing CUBRID as a zip file on Windows, execution may fail because there is no DLL, environment variables or registry settings are not set.
In this case, DLL installation, environment variables, and registry settings are required.