### PR TITLE
[CUBRIDMAN-55] In driver, Update On Build Environment And About Support PHP Version.

### DIFF
--- a/en/api/pdo.rst
+++ b/en/api/pdo.rst
@@ -31,7 +31,7 @@ Linux
 
 *   Operating system: 32-bit or 64-bit Linux
 *   Web server: Apache
-*   PHP: 5.6.x, or 7.1.x (https://www.php.net/downloads.php)
+*   PHP: 5.6.x, 7.1.x, or 7.4.x (https://www.php.net/downloads.php)
 
 **Installing CUBRID PHP Driver using PECL**
 
@@ -67,8 +67,8 @@ Windows
 
 *   Operating system: 32-bit or 64-bit Windows
 *   Web server: Apache or IIS
-*   PHP: 5.6.x or 7.1.x (https://windows.php.net/download/)
-*   For PHP 7.1.x, you need to install Microsoft Visual C++ 2015 Redistributable Package for 32bit or 64bit.
+*   PHP: 5.6.x, 7.1.x, or 7.4.x (https://windows.php.net/download/)
+*   For PHP 7.1.x or 7.4.x, you need to install Microsoft Visual C++ 2015 Redistributable Package for 32bit or 64bit.
 
 **Downloading and Installing Compiled CUBRID PDO Driver**
 
@@ -95,6 +95,12 @@ After you download the driver, you will see the **php_cubrid.dll** file for CUBR
         extension = php_pdo_cubrid.dll
 
 #.  Restart your web server to apply changes.
+
+Building CUBRID PHP Driver from Source Code
+===========================================
+
+Building CUBRID PDO driver and :ref:`Building CUBRID PHP driver from source code<how-to-php-driver-build>` \are the same.
+
 
 PDO Programming
 ===============

--- a/en/api/perl.rst
+++ b/en/api/perl.rst
@@ -30,6 +30,8 @@ Installing and Configuring Perl
 
 *   C compiler: In most cases, there are binary distributions of **DBD::cubrid** ( https://www.cubrid.org/downloads#perl ) available. However, if you want to build the driver from source code, a C compiler is required. Make sure to use the same C compiler that was used for compiling Perl and CUBRID. Otherwise, you will encounter problems because of differences in the underlying C runtime libraries.
 
+*   For Building CCI Driver In Linux, GNU Developer Toolset 8 or higher is required.
+
 **Comprehensive Perl Archive Network (CPAN) Installation**
 
 You can automatically install the driver from source code by using the CPAN module. ::

--- a/en/api/perl.rst
+++ b/en/api/perl.rst
@@ -30,7 +30,7 @@ Installing and Configuring Perl
 
 *   C compiler: In most cases, there are binary distributions of **DBD::cubrid** ( https://www.cubrid.org/downloads#perl ) available. However, if you want to build the driver from source code, a C compiler is required. Make sure to use the same C compiler that was used for compiling Perl and CUBRID. Otherwise, you will encounter problems because of differences in the underlying C runtime libraries.
 
-*   For Building CCI Driver In Linux, GNU Developer Toolset 8 or higher is required.
+*   For building CCI Driver In Linux, GNU Developer Toolset 8 or higher is required.
 
 **Comprehensive Perl Archive Network (CPAN) Installation**
 

--- a/en/api/php.rst
+++ b/en/api/php.rst
@@ -205,7 +205,7 @@ In this section, we will introduce the way of building CUBRID PHP driver for Lin
 *   PHP 5.6.x, 7.1.x or 7.4.x source code: You can download PHP source code from https://www.php.net/downloads.php .
 *   Apache 2: It can be used to test PHP.
 *   CUBRID PHP driver source code: You can download the source code from https://www.cubrid.org/downloads#php . Make sure that the version you download is the same as the version of CUBRID which has been installed on your system.
-*   IF Building CCI driver In Linux Or Mac, GNU Developer Toolset 8 or higher is required.
+*   IF building CCI driver In Linux Or Mac, GNU Developer Toolset 8 or higher is required.
 
 **Compiling CUBRID PHP driver**
 

--- a/en/api/php.rst
+++ b/en/api/php.rst
@@ -29,7 +29,7 @@ For Linux
 *   Operating system: 32-bit or 64-bit Linux
 *   Web server: Apache
 *   PHP: version 5.x, or version 7.x (https://www.php.net/downloads.php)
-*	We refer to the latest PHP versions 5.6.x and 7.1.x as a convenience.
+*	We refer to the latest PHP versions 5.6.x ,7.1.x and 7.4.x as a convenience.
 
 **Installing CUBRID PHP Driver using PECL**
 
@@ -104,8 +104,8 @@ For Windows
 *   CUBRID: 9.3.x or later
 *   Operating system: 32-bit or 64 bit Windows
 *   Web server: Apache or IIS
-*   PHP: 5.6.x or 7.1.x (https://windows.php.net/download/)
-*   For PHP 7.1.x, you need to install Microsoft Visual C++ 2015 Redistributable Package for 32bit or 64bit.
+*   PHP: 5.6.x, 7.1.x or 7.4.x (https://windows.php.net/download/)
+*   For PHP 7.1.x or 7.4.x, you need to install Microsoft Visual C++ 2015 Redistributable Package for 32bit or 64bit.
 
 **Using CUBRID PHP Driver Installer**
 
@@ -189,6 +189,8 @@ After you download the driver, you will see the **php_cubrid.dll** file for CUBR
     
 #.  Restart your web server to apply changes.
 
+.. _how-to-php-driver-build:
+
 Building CUBRID PHP Driver from Source Code
 ===========================================
 
@@ -200,9 +202,10 @@ In this section, we will introduce the way of building CUBRID PHP driver for Lin
 **Configuring the environment**
 
 *   CUBRID: Install CUBRID. Make sure the environment variable **%CUBRID%** is defined in your system.
-*   PHP 5.6.x or 7.1.x source code: You can download PHP source code from https://www.php.net/downloads.php .
+*   PHP 5.6.x, 7.1.x or 7.4.x source code: You can download PHP source code from https://www.php.net/downloads.php .
 *   Apache 2: It can be used to test PHP.
 *   CUBRID PHP driver source code: You can download the source code from https://www.cubrid.org/downloads#php . Make sure that the version you download is the same as the version of CUBRID which has been installed on your system.
+*   IF Building CCI driver In Linux Or Mac, GNU Developer Toolset 8 or higher is required.
 
 **Compiling CUBRID PHP driver**
 

--- a/en/api/python.rst
+++ b/en/api/python.rst
@@ -28,8 +28,9 @@ There are three ways to install CUBRID Python driver on Linux, UNIX, and UNIX-li
 **Building CUBRID Python Driver from Source Code (Linux)**
 
 To install CUBRID Python driver by compiling source code, you should have Python Development Package installed on your system. 
-
 .. FIXME: If you do not have the package, follow the instructions stated at http://www.cubrid.org/wiki_apis/entry/install-python-development-package .
+
+#.  For Building CCI Driver, GNU Developer Toolset 8 or higher is required.
 
 #.  Download the source code from https://www.cubrid.org/downloads#python.
 

--- a/en/api/python.rst
+++ b/en/api/python.rst
@@ -28,6 +28,7 @@ There are three ways to install CUBRID Python driver on Linux, UNIX, and UNIX-li
 **Building CUBRID Python Driver from Source Code (Linux)**
 
 To install CUBRID Python driver by compiling source code, you should have Python Development Package installed on your system. 
+
 .. FIXME: If you do not have the package, follow the instructions stated at http://www.cubrid.org/wiki_apis/entry/install-python-development-package .
 
 #.  For Building CCI Driver, GNU Developer Toolset 8 or higher is required.

--- a/en/api/python.rst
+++ b/en/api/python.rst
@@ -31,7 +31,7 @@ To install CUBRID Python driver by compiling source code, you should have Python
 
 .. FIXME: If you do not have the package, follow the instructions stated at http://www.cubrid.org/wiki_apis/entry/install-python-development-package .
 
-#.  For Building CCI Driver, GNU Developer Toolset 8 or higher is required.
+#.  For building CCI Driver, GNU Developer Toolset 8 or higher is required.
 
 #.  Download the source code from https://www.cubrid.org/downloads#python.
 

--- a/ko/api/pdo.rst
+++ b/ko/api/pdo.rst
@@ -31,7 +31,7 @@ Linux
 
 *   운영체제: Linux: 32 비트 또는 64비트
 *   웹 서버: Apache
-*   PHP: 5.6.x, 또는 7.1.x (https://www.php.net/downloads.php)
+*   PHP: 5.6.x, 7.1.x, 또는 7.4.x (https://www.php.net/downloads.php)
 
 **PECL을 이용한 설치**
 
@@ -67,8 +67,8 @@ Windows
 
 *   운영체제: Windows 32 비트 또는 64비트
 *   웹 서버: Apache 또는 IIS
-*   PHP: 5.6.x 또는 7.1.x(https://windows.php.net/download/)
-*   PHP 7.1.x 의 경우 32bit 또는 64bit용 Microsoft Visual C ++ 2015 재배포 가능 패키지를 설치해야 한다.
+*   PHP: 5.6.x, 7.1.x 또는 7.4.x(https://windows.php.net/download/)
+*   PHP 7.1.x 또는 7.4.x 의 경우 32bit 또는 64bit용 Microsoft Visual C ++ 2015 재배포 가능 패키지를 설치해야 한다.
 
 **빌드된 드라이버 다운로드 및 설치**
 
@@ -95,6 +95,11 @@ PDO 드라이버를 다운로드하면 **php_cubrid.dll** 파일을 볼 수 있�
         extension = php_pdo_cubrid.dll
 
 #.  웹 서버를 재시작한다.
+
+PHP 드라이버 빌드
+=================
+
+CUBRID PDO 드라이버를 빌드하는 방법은 :ref:`CUBRID PHP 드라이버를 빌드하는 방법<how-to-php-driver-build>`\과 동일하므로 참고하여 진행한다.
 
 PDO 프로그래밍
 ==============

--- a/ko/api/perl.rst
+++ b/ko/api/perl.rst
@@ -30,6 +30,8 @@ Perl 설치 및 설정
 
 *   C 컴파일러: 대부분의 경우에는 **DBD::cubrid** 바이너리(https://www.cubrid.org/downloads#perl)를 사용할 수 있으나, 만약 소스코드에서 드라이버를 빌드하려면 C 컴파일러가 필요하다. C 컴파일러를 사용하려면 Perl과 CUBRID를 컴파일한 컴파일러와 같은 컴파일러를 사용해야 한다. 그렇지 않으면 C 런타임 라이브러리 차이 때문에 문제가 발생할 수 있다.
 
+*   Linux에서는 CCI Driver를 빌드하기 위해 GNU Developer Toolset 8 또는 그 이상이 필요하다.
+
 **CPAN을 이용한 설치**
 
 다음과 같이 **CPAN** (Comprehensive Perl Archive Network)을 사용하면 자동으로 소스코드에서 드라이버를 설치할 수 있다. ::

--- a/ko/api/php.rst
+++ b/ko/api/php.rst
@@ -30,7 +30,7 @@ Linux
 *   웹 서버: Apache
 *   PHP: 5.2 또는 5.3( https://www.php.net/downloads.php )
 *   PHP: 5.x, 또는 7.x (https://www.php.net/downloads.php)
-*   편의상 최신 PHP 5.6.x 및 7.1.x를 참조 바랍니다.
+*   편의상 최신 PHP 5.6.x, 7.1.x 및 7.4.x를 참조 바랍니다.
 
 **PECL을 이용한 설치**
 
@@ -104,8 +104,8 @@ Windows
 *   CUBRID: 9.3.x 이상
 *   운영체제: Windows 32 비트 또는 64비트
 *   웹 서버: Apache 또는 IIS
-*   PHP: 5.6.x 또는 7.1.x(https://windows.php.net/download/)
-*   PHP 7.1.x 의 경우 32bit 또는 64bit용 Microsoft Visual C ++ 2015 재배포 가능 패키지를 설치해야 한다.
+*   PHP: 5.6.x, 7.1.x 또는 7.4.x(https://windows.php.net/download/)
+*   PHP 7.1.x 또는 7.4.x 의 경우 32bit 또는 64bit용 Microsoft Visual C ++ 2015 재배포 가능 패키지를 설치해야 한다.
 
 **CUBRID PHP API Installer를 사용한 설치**
 
@@ -191,6 +191,8 @@ PHP 드라이버를 다운로드하면 **php_cubrid.dll** 파일을 볼 수 있�
     
 #.  웹 서버를 재시작한다.
 
+.. _how-to-php-driver-build:
+
 PHP 드라이버 빌드
 =================
 
@@ -202,9 +204,10 @@ Linux
 **환경 설정**
 
 *   CUBRID: CUBRID를 설치한다. 시스템에 환경 변수 **%CUBRID%** 가 정의되어 있는지 확인한다.
-*   PHP 5.6.x 또는 7.1.x 소스코드: PHP 5.3 소스코드를 다음 주소에서 다운로드한다. https://www.php.net/downloads.php
+*   PHP 5.6.x , 7.1.x 또는 7.4.x 소스코드: PHP 5.3 소스코드를 다음 주소에서 다운로드한다. https://www.php.net/downloads.php
 *   Apache 2: PHP 테스트에 Apache 2를 사용할 수 있다.
 *   CUBRID PHP 드라이버 소스코드: https://www.cubrid.org/downloads#php 에서 CUBRID 버전에 맞는 CUBRID PHP 드라이버의 소스코드를 다운로드한다.
+*   Linux 또는 Mac 에서는 CCI 드라이버 빌드를 하려면 GNU Developer Toolset 8 또는 그 이상이 필요하다.
 
 **CUBRID PHP 드라이브 빌드**
 

--- a/ko/api/python.rst
+++ b/ko/api/python.rst
@@ -31,6 +31,8 @@ Linux, Unix 및 유사 운영체제에서는 다음과 같은 세 가지 방법�
 
 .. FIXME: Python Development Package가 설치되어 있지 않다면 http://www.cubrid.org/wiki_apis/entry/install-python-development-package\ 를 참고하여 설치한다.
 
+#.  CCI 드라이버 빌드하기 위해 GNU Developer Toolset 8 또는 그 이상이 필요하다.
+
 #.  소스 코드를 https://www.cubrid.org/downloads#python\에서 다운로드한다.
 
 #.  다음 명령어를 실행하여 원하는 위치에 다운로드한 파일의 압축을 해제한다. ::


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-55

Purpose
In Driver related to CCI, update on Build Compiler(GNU Devtoolset 8).
In CUBRID v11.0.0 PHP and PDO Driver, supports PHP 7.4 Version.
Implementation
N/A
Remarks
en) http://192.168.1.8:35420/index.html
ko) http://192.168.1.8:35421/index.html
