### PR TITLE
[CUBRIDMAN-56] Remove a wrong empty line

### DIFF
--- a/en/security.rst
+++ b/en/security.rst
@@ -162,9 +162,8 @@ The key file can contain several master keys (up to 128). A master key among tho
 	The number of keys: 4
 
 .. note:: **Creating a database using an existing key file**
-
     
-If you want to create a new database using a key file that was previously managed for reasons such as security policy, copy or move the key file to the directory where the database will be created before creating it. The name of the key file must be changed to **<database_name>_keys**. If you're using the **tde_keys_file_path** system parameter, you have to copy the key file to the path.
+    If you want to create a new database using a key file that was previously managed for reasons such as security policy, copy or move the key file to the directory where the database will be created before creating it. The name of the key file must be changed to **<database_name>_keys**. If you're using the **tde_keys_file_path** system parameter, you have to copy the key file to the path.
 
 .. _tde-enc-target:
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-56

There was a wrong empty line to break the format. Sorry for missing it.