### PR TITLE
[CUBRIDMAN-63] fix typo at the loaddb's example

### DIFF
--- a/en/admin/migration.inc
+++ b/en/admin/migration.inc
@@ -300,7 +300,7 @@ The following table shows [options] available with the **cubrid loaddb** utility
 
     This option specifies the table name if a table name header is omitted in the data file to be loaded. ::
 
-        cubrid loaded -u dba -d demodb_objects -t tbl_name newdb
+        cubrid loaddb -u dba -d demodb_objects -t tbl_name newdb
 
 .. option:: --error-control-file=FILE
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-63

* fix the command of 'loaddb' which shows the example of -t option