### PR TITLE
[CUBRIDMAN-90] fix to FOREIGN KEY can be omitted in column_constraint

### DIFF
--- a/en/sql/schema/table_stmt.rst
+++ b/en/sql/schema/table_stmt.rst
@@ -44,7 +44,7 @@ To create a table, use the **CREATE TABLE** statement.
 
             <on_update> ::= [ON UPDATE <value_specification>]
 
-            <column_constraint> ::= [CONSTRAINT constraint_name] { NOT NULL | UNIQUE | PRIMARY KEY | FOREIGN KEY <referential_definition> }
+            <column_constraint> ::= [CONSTRAINT constraint_name] { NOT NULL | UNIQUE | PRIMARY KEY | [FOREIGN KEY] <referential_definition> }
 
                 <referential_definition> ::=
                     REFERENCES [referenced_table_name] (column_name, ...) [<referential_triggered_action> ...]
@@ -154,7 +154,7 @@ A column is a set of data values of a particular simple type, one for each row o
 
         <on_update> ::= [ON UPDATE <value_specification>]
 
-        <column_constraint> ::= [CONSTRAINT constraint_name] {NOT NULL | UNIQUE | PRIMARY KEY | FOREIGN KEY <referential_definition>}
+        <column_constraint> ::= [CONSTRAINT constraint_name] {NOT NULL | UNIQUE | PRIMARY KEY | [FOREIGN KEY] <referential_definition>}
 
 Column Name
 ^^^^^^^^^^^
@@ -418,7 +418,7 @@ You can define **NOT NULL**, **UNIQUE**, **PRIMARY KEY**, **FOREIGN KEY** as the
 
 ::
 
-    <column_constraint> ::= [CONSTRAINT constraint_name] { NOT NULL | UNIQUE | PRIMARY KEY | FOREIGN KEY <referential_definition> }
+    <column_constraint> ::= [CONSTRAINT constraint_name] { NOT NULL | UNIQUE | PRIMARY KEY | [FOREIGN KEY] <referential_definition> }
 
     <table_constraint> ::=
         [CONSTRAINT [constraint_name]] 
@@ -1089,7 +1089,7 @@ You can add a new column by using the **ADD COLUMN** clause. You can specify the
 
             <on_update> ::= [ON UPDATE <value_specification>]
 
-            <column_constraint> ::= [CONSTRAINT constraint_name] {NOT NULL | UNIQUE | PRIMARY KEY | FOREIGN KEY <referential_definition>}
+            <column_constraint> ::= [CONSTRAINT constraint_name] {NOT NULL | UNIQUE | PRIMARY KEY | [FOREIGN KEY] <referential_definition>}
 
                 <referential_definition> ::=
                     REFERENCES [referenced_table_name] (column_name, ...) [<referential_triggered_action> ...]

--- a/ko/sql/schema/table_stmt.rst
+++ b/ko/sql/schema/table_stmt.rst
@@ -45,7 +45,7 @@ CREATE TABLE
 
                 <on_update> ::= [ON UPDATE <value_specification>]
          
-            <column_constraint> ::= [CONSTRAINT constraint_name] { NOT NULL | UNIQUE | PRIMARY KEY | FOREIGN KEY <referential_definition> }
+            <column_constraint> ::= [CONSTRAINT constraint_name] { NOT NULL | UNIQUE | PRIMARY KEY | [FOREIGN KEY] <referential_definition> }
 
                 <referential_definition> ::=
                     REFERENCES [referenced_table_name] (column_name, ...) [<referential_triggered_action> ...]
@@ -157,7 +157,7 @@ CREATE TABLE
 
         <on_update> ::= [ON UPDATE <value_specification>]
 
-        <column_constraint> ::= [CONSTRAINT constraint_name] {NOT NULL | UNIQUE | PRIMARY KEY | FOREIGN KEY <referential_definition>}
+        <column_constraint> ::= [CONSTRAINT constraint_name] {NOT NULL | UNIQUE | PRIMARY KEY | [FOREIGN KEY] <referential_definition>}
 
 칼럼 이름
 ^^^^^^^^^
@@ -419,7 +419,7 @@ ON UPDATE
 
 ::
 
-    <column_constraint> ::= [CONSTRAINT constraint_name] { NOT NULL | UNIQUE | PRIMARY KEY | FOREIGN KEY <referential_definition> }
+    <column_constraint> ::= [CONSTRAINT constraint_name] { NOT NULL | UNIQUE | PRIMARY KEY | [FOREIGN KEY] <referential_definition> }
 
     <table_constraint> ::=
         [CONSTRAINT [constraint_name]] 
@@ -1093,7 +1093,7 @@ ADD COLUMN 절
 
             <on_update> ::= [ON UPDATE <value_specification>]
             
-            <column_constraint> ::= [CONSTRAINT constraint_name] {NOT NULL | UNIQUE | PRIMARY KEY | FOREIGN KEY <referential_definition>}
+            <column_constraint> ::= [CONSTRAINT constraint_name] {NOT NULL | UNIQUE | PRIMARY KEY | [FOREIGN KEY] <referential_definition>}
 
                 <referential_definition> ::=
                     REFERENCES [referenced_table_name] (column_name, ...) [<referential_triggered_action> ...]


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-90


Unlike <table_constraint> in <column_constraint>, "FOREIGN KEY" can be omitted.

example below
```
create table t1 (c1 int primary key);
 
-- create 
-- All of the following statements are possible
create table t2 (c1 int                                  references t1 (c1)); 
create table t3 (c1 int CONSTRAINT fk1                   references t1 (c1)); 
create table t5 (c1 int CONSTRAINT fk2 FOREIGN KEY       references t1 (c1)); 

-- alter
create tabel t6 (c1 int);
-- All of the following statements are possible
alter table t6 add column(c2 int  CONSTRAINT fk1   references t1 (c1));
alter table t6 add column(c3 int  CONSTRAINT fk2  FOREIGN KEY  references t1 (c1));
```
