### PR TITLE
[CUBRIDMAN-93] Addition prefix 'dba.' to the checksumdb utility results 'db_ha_checksum' in the Checksumdb paragraph -n option.

### DIFF
--- a/en/ha.rst
+++ b/en/ha.rst
@@ -3515,7 +3515,7 @@ checksumdb
     
 .. option:: -n, --table-name=STRING
 
-    You can specify a table name to save checksum results. The table name must include the owner's name which can only be dba. (default: dba.db_ha_checksum).
+    You can specify a table name to save checksum results. The table name must include the owner's name which can only be dba. (default: dba.db_ha_checksum)
     
 .. option:: -r, --report-only
 

--- a/en/ha.rst
+++ b/en/ha.rst
@@ -3515,7 +3515,7 @@ checksumdb
     
 .. option:: -n, --table-name=STRING
 
-    You can specify a table name to save checksum results. (default: db_ha_checksum)
+    You can specify a table name to save checksum results. (default: dba.db_ha_checksum)
     
 .. option:: -r, --report-only
 

--- a/en/ha.rst
+++ b/en/ha.rst
@@ -3515,7 +3515,7 @@ checksumdb
     
 .. option:: -n, --table-name=STRING
 
-    You can specify a table name to save checksum results. (default: dba.db_ha_checksum)
+    You can specify a table name to save checksum results. The table name must include the owner's name which can only be dba. (default: dba.db_ha_checksum).
     
 .. option:: -r, --report-only
 

--- a/ko/ha.rst
+++ b/ko/ha.rst
@@ -3512,7 +3512,7 @@ checksumdb
 
 .. option:: -n, --table-name=STRING
 
-     체크섬 결과를 저장할 테이블명을 지정한다. (기본값: dba.db_ha_checksum)
+     체크섬 결과를 저장할 테이블명을 지정한다. 테이블명에는 반드시 테이블 소유자명 dba만 포함되어야 한다. (기본값: dba.db_ha_checksum)
 
 .. option:: -r, --report-only
 

--- a/ko/ha.rst
+++ b/ko/ha.rst
@@ -3512,7 +3512,7 @@ checksumdb
 
 .. option:: -n, --table-name=STRING
 
-     체크섬 결과를 저장할 테이블명을 지정한다. (기본값: db_ha_checksum)
+     체크섬 결과를 저장할 테이블명을 지정한다. (기본값: dba.db_ha_checksum)
 
 .. option:: -r, --report-only
 

--- a/ko/ha.rst
+++ b/ko/ha.rst
@@ -3512,7 +3512,7 @@ checksumdb
 
 .. option:: -n, --table-name=STRING
 
-     체크섬 결과를 저장할 테이블명을 지정한다. 테이블명은 "테이블의 소유자명.테이블명"의 형식으로 지정해야하고 소유자명은 dba만 포함되어야 한다. (기본값: dba.db_ha_checksum)
+     체크섬 결과를 저장할 테이블명을 지정한다. 테이블명 입력 시 "소유자명.테이블명" 형식을 사용해야 하며, 현재는 소유자명으로 dba만 지정할 수 있다. (기본값: dba.db_ha_checksum)
 
 .. option:: -r, --report-only
 

--- a/ko/ha.rst
+++ b/ko/ha.rst
@@ -3512,7 +3512,7 @@ checksumdb
 
 .. option:: -n, --table-name=STRING
 
-     체크섬 결과를 저장할 테이블명을 지정한다. 테이블명에는 반드시 테이블 소유자명 dba만 포함되어야 한다. (기본값: dba.db_ha_checksum)
+     체크섬 결과를 저장할 테이블명을 지정한다. 테이블명은 "테이블의 소유자명.테이블명"의 형식으로 지정해야하고 소유자명은 dba만 포함되어야 한다. (기본값: dba.db_ha_checksum)
 
 .. option:: -r, --report-only
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-93

