### PR TITLE
[CUBRIDMAN-89] Revise Java SP manual

### DIFF
--- a/en/sql/jsp.rst
+++ b/en/sql/jsp.rst
@@ -125,7 +125,7 @@ Call the published Java stored function as follows:
 
 .. code-block:: sql
 
-    CALL hello() INTO :Hello;
+    SELECT hello();
 
 ::
 
@@ -610,8 +610,6 @@ In CUBRID, you must use **CURSOR** as the data type when you declare a Java stor
     CREATE FUNCTION rset() RETURN CURSOR AS LANGUAGE JAVA
     NAME 'JavaSP2.TResultSet() return java.sql.ResultSet'
 
-Before the Java file returns **java.sql.ResultSet**, it is required to cast to the **CUBRIDResultSet** class and then to call the **setReturnable** () method.
-
 .. code-block:: java
 
     import java.sql.Connection;
@@ -626,12 +624,10 @@ Before the Java file returns **java.sql.ResultSet**, it is required to cast to t
         public static ResultSet TResultSet(){
             try {
                 Connection conn = DriverManager.getConnection("jdbc:default:connection:");
-                ((CUBRIDConnection)conn).setCharset("euc_kr");
                     
                 String sql = "select * from station";
                 Statement stmt=conn.createStatement();
                 ResultSet rs = stmt.executeQuery(sql);
-                ((CUBRIDResultSet)rs).setReturnable();
                     
                 return rs;
             } catch (Exception e) {
@@ -689,7 +685,7 @@ If the set type of the Java stored function/procedure in CUBRID is IN OUT, the v
 
 .. code-block:: java
 
-    public static void SetOID(cubrid.sql.CUBRID[][] set, cubrid.sql.CUBRIDOID aoid){
+    public static void SetOID(cubrid.sql.CUBRIDOID[][] set, cubrid.sql.CUBRIDOID aoid){
         Connection conn=null;
         Statement stmt=null;
         String ret="";

--- a/en/sql/jsp.rst
+++ b/en/sql/jsp.rst
@@ -140,7 +140,6 @@ To access the database from a Java stored function/procedure, you must use the s
 
 .. code-block:: java
 
-    Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
     Connection conn = DriverManager.getConnection("jdbc:default:connection:");
 
 or
@@ -160,7 +159,6 @@ If you connect to the database using the JDBC driver as shown above, the transac
             String sql="INSERT INTO ATHLETE(NAME, GENDER, NATION_CODE, EVENT)" + "VALUES (?, ?, ?, ?)";
             
             try{
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 Connection conn = DriverManager.getConnection("jdbc:default:connection:");
                 PreparedStatement pstmt = conn.prepareStatement(sql);
            
@@ -198,7 +196,6 @@ If you connect to other databases, the connection to the CUBRID database does no
             ResultSet rs = null;
 
             try {
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 conn = DriverManager.getConnection("jdbc:CUBRID:localhost:33000:demodb:::","","");
 
                 String sql = "select line_id, line from line";
@@ -500,7 +497,6 @@ Compile the following **PhoneNumber.java** file, load the Java class file into C
         public static void Phone(String name, String phoneno) throws Exception{
             String sql="INSERT INTO PHONE(NAME, PHONENO)"+ "VALUES (?, ?)";
             try{
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 Connection conn = DriverManager.getConnection("jdbc:default:connection:");
                 PreparedStatement pstmt = conn.prepareStatement(sql);
            
@@ -536,7 +532,6 @@ Create and run the following Java application.
             int i;
 
             try{
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 conn = DriverManager.getConnection("jdbc:CUBRID:localhost:33000:demodb:::","","");
 
                 CallableStatement cs;
@@ -630,7 +625,6 @@ Before the Java file returns **java.sql.ResultSet**, it is required to cast to t
     public class JavaSP2 {
         public static ResultSet TResultSet(){
             try {
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 Connection conn = DriverManager.getConnection("jdbc:default:connection:");
                 ((CUBRIDConnection)conn).setCharset("euc_kr");
                     
@@ -663,7 +657,6 @@ In the calling block, you must set the OUT argument with **Types.JAVA_OBJECT**, 
             Connection conn = null;
      
             try {
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 conn = DriverManager.getConnection("jdbc:CUBRID:localhost:31001:tdemodb:::","","");
      
                 CallableStatement cstmt = conn.prepareCall("?=CALL rset()");

--- a/ko/sql/jsp.rst
+++ b/ko/sql/jsp.rst
@@ -158,7 +158,6 @@ Java 저장 함수/프로시저에서 데이터베이스에 접근하기 위해�
             String sql="INSERT INTO ATHLETE(NAME, GENDER, NATION_CODE, EVENT)" + "VALUES (?, ?, ?, ?)";
             
             try{
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 Connection conn = DriverManager.getConnection("jdbc:default:connection:");
                 PreparedStatement pstmt = conn.prepareStatement(sql);
            
@@ -196,7 +195,6 @@ Java 저장 함수/프로시저에서 데이터베이스에 접근하기 위해�
             ResultSet rs = null;
 
             try {
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 conn = DriverManager.getConnection("jdbc:CUBRID:localhost:33000:demodb:::","","");
 
                 String sql = "select line_id, line from line";
@@ -498,7 +496,6 @@ CUBRID 데이터베이스에 Phone 클래스를 생성한다.
         public static void Phone(String name, String phoneno) throws Exception{
             String sql="INSERT INTO PHONE(NAME, PHONENO)"+ "VALUES (?, ?)";
             try{
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 Connection conn = DriverManager.getConnection("jdbc:default:connection:");
                 PreparedStatement pstmt = conn.prepareStatement(sql);
            
@@ -534,7 +531,6 @@ CUBRID 데이터베이스에 Phone 클래스를 생성한다.
             int i;
 
             try{
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 conn = DriverManager.getConnection("jdbc:CUBRID:localhost:33000:demodb:::","","");
 
                 CallableStatement cs;
@@ -628,7 +624,6 @@ Java 파일에서는 **java.sql.ResultSet** 을 반환하기 전에 **CUBRIDResu
     public class JavaSP2 {
         public static ResultSet TResultSet(){
             try {
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 Connection conn = DriverManager.getConnection("jdbc:default:connection:");
                 ((CUBRIDConnection)conn).setCharset("euc_kr");
                     
@@ -661,7 +656,6 @@ Java 파일에서는 **java.sql.ResultSet** 을 반환하기 전에 **CUBRIDResu
             Connection conn = null;
      
             try {
-                Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
                 conn = DriverManager.getConnection("jdbc:CUBRID:localhost:31001:tdemodb:::","","");
      
                 CallableStatement cstmt = conn.prepareCall("?=CALL rset()");

--- a/ko/sql/jsp.rst
+++ b/ko/sql/jsp.rst
@@ -123,7 +123,7 @@ Java 저장 함수/프로시저 호출
 
 .. code-block:: sql
 
-    CALL hello() INTO :Hello;
+    SELECT hello();
 
 ::
 
@@ -138,7 +138,6 @@ Java 저장 함수/프로시저에서 데이터베이스에 접근하기 위해�
 
 .. code-block:: java
 
-    Class.forName("cubrid.jdbc.driver.CUBRIDDriver");
     Connection conn = DriverManager.getConnection("jdbc:default:connection:");
 
 또는
@@ -609,8 +608,6 @@ CUBRID에서는 **java.sql.ResultSet** 을 반환하는 Java 저장 함수/프�
     CREATE FUNCTION rset() RETURN CURSOR AS LANGUAGE JAVA
     NAME 'JavaSP2.TResultSet() return java.sql.ResultSet'
 
-Java 파일에서는 **java.sql.ResultSet** 을 반환하기 전에 **CUBRIDResultSet** 클래스로 캐스팅 후 **setReturnable** () 메서드를 호출해야 한다.
-
 .. code-block:: java
 
     import java.sql.Connection;
@@ -625,12 +622,10 @@ Java 파일에서는 **java.sql.ResultSet** 을 반환하기 전에 **CUBRIDResu
         public static ResultSet TResultSet(){
             try {
                 Connection conn = DriverManager.getConnection("jdbc:default:connection:");
-                ((CUBRIDConnection)conn).setCharset("euc_kr");
                     
                 String sql = "select * from station";
                 Statement stmt=conn.createStatement();
                 ResultSet rs = stmt.executeQuery(sql);
-                ((CUBRIDResultSet)rs).setReturnable();
                     
                 return rs;
             } catch (Exception e) {
@@ -688,7 +683,7 @@ CUBRID의 Java 저장 함수/프로시저에서 Set 타입이 IN OUT인 경우 J
 
 .. code-block:: java
 
-    public static void SetOID(cubrid.sql.CUBRID[][] set, cubrid.sql.CUBRIDOID aoid){
+    public static void SetOID(cubrid.sql.CUBRIDOID[][] set, cubrid.sql.CUBRIDOID aoid){
         Connection conn=null;
         Statement stmt=null;
         String ret="";


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-89

In this PR, the following are revised.
- setReturnable () is not required anymore to return CURSOR.
- Remove redundant "Class.forName("cubrid.jdbc.driver.CUBRIDDriver");"
- Fix typo (cubrid.sql.CUBRID -> cubrid.sql.CUBRIDOID)