### PR TITLE
[CUBRIDMAN-98] Remove the example for INDEX RENAME

### DIFF
--- a/en/sql/schema/index_stmt.rst
+++ b/en/sql/schema/index_stmt.rst
@@ -273,12 +273,6 @@ The below is a syntax to only add or change a comment without rebuilding an inde
     
     ALTER INDEX i_game_medal ON game COMMENT 'change index comment' ;
 
-The following is a syntax of renaming an index.
-
-.. code-block:: sql
-
-    ALTER INDEX old_index_name ON table_name RENAME TO new_index_name [COMMENT 'index_comment_string'] ;
-
 The following is a syntax to change the status of an index to **INVISIBLE**/**VISIBLE**. When an index is set as **INVISIBLE**, queries will be executed as like the index does not exist. In this way, the performance of the index may be tested and the impact of its removal be evaluated without actually dropping the index.
 
 .. code-block:: sql

--- a/ko/sql/schema/index_stmt.rst
+++ b/ko/sql/schema/index_stmt.rst
@@ -270,12 +270,6 @@ ALTER INDEX
     
     ALTER INDEX i_game_medal ON game COMMENT 'change index comment' ;
 
-다음은 인덱스 이름을 바꾸는 구문이다. 
-
-.. code-block:: sql
-
-    ALTER INDEX old_index_name ON table_name RENAME TO new_index_name [COMMENT 'index_comment_string'] ;
-
 다음은 인덱스의 상태를 **INVISIBLE**/**VISIBLE** 로 변경하기 위한 구문이다. 인덱스의 상태가 **INVISIBLE** 인 경우, 질의 실행은 인덱스가 없는 것처럼 수행된다. 이 방법으로 인덱스의 성능 측정이 가능하며, 실제로 인덱스를 제거하지 않고 인덱스 제거에 따른 영향도를 측정할 수있다.
 
 .. code-block:: sql


### PR DESCRIPTION
The ALTER INDEX clause is not supported since 10.x. Therefore, we should remove the related example to apply it.

`ALTER INDEX old_index_name ON table_name RENAME TO new_index_name [COMMENT 'index_comment_string'] ; 
` 