### PR TITLE
[CUBRIDMAN-101] Modify the specification for source of MERGE statement

### DIFF
--- a/en/sql/query/merge.rst
+++ b/en/sql/query/merge.rst
@@ -6,12 +6,12 @@
 MERGE
 *****
 
-The **MERGE** statement is used to select rows from one or more sources and to update or to insert the rows onto one table or view. You can specify the condition whether to update or to insert the rows onto the target table or view. The **MERGE** statement is a deterministic statement, so you cannot update the same rows on the target table several times within one sentence.
+The **MERGE** statement is used to select rows from a source and to update or to insert the rows onto one table or view. You can specify the condition whether to update or to insert the rows onto the target table or view. The **MERGE** statement is a deterministic statement, so you cannot update the same rows on the target table several times within one sentence.
 
 ::
 
     MERGE [<merge_hint>] INTO <target> [[AS] <alias>]
-    USING <source> [[AS] <alias>], <source> [[AS] <alias>], ...
+    USING <source> [[AS] <alias>]
     ON <join_condition>
     [ <merge_update_clause> ]
     [ <merge_insert_clause> ]
@@ -28,7 +28,7 @@ The **MERGE** statement is used to select rows from one or more sources and to u
     /*+ [ USE_UPDATE_IDX (<update_index_list>) ] [ USE_INSERT_IDX (<insert_index_list>) ] */
 
 *   <*target*>: Target table to be updated or inserted. Several tables or views are available.
-*   <*source*>: Source table to get the data. Several tables or views are available and sub-query is available, too.
+*   <*source*>: Source table to get the data. a single table or a single view is available and a sub-query is available, too.
 *   <*join_condition*>: Specifies the updated conditions
 *   <*merge_update_clause*>: If <*join_condition*> is TRUE, the new column value of a target table will be specified.
 
@@ -179,4 +179,4 @@ The following shows how to use index hints in **MERGE** statement.
     INTO target t USING source s ON t.i=s.i 
     WHEN MATCHED THEN UPDATE SET t.j=s.j WHERE s.i <> 1
     WHEN NOT MATCHED THEN INSERT VALUES (i,j);
-     
+

--- a/en/sql/query/merge.rst
+++ b/en/sql/query/merge.rst
@@ -28,7 +28,7 @@ The **MERGE** statement is used to select rows from a source and to update or to
     /*+ [ USE_UPDATE_IDX (<update_index_list>) ] [ USE_INSERT_IDX (<insert_index_list>) ] */
 
 *   <*target*>: Target table to be updated or inserted. Several tables or views are available.
-*   <*source*>: Source table to get the data. a single table or a single view is available and a sub-query is available, too.
+*   <*source*>: Source table to get the data. A single table or a single view is available and a sub-query is available, too.
 *   <*join_condition*>: Specifies the updated conditions
 *   <*merge_update_clause*>: If <*join_condition*> is TRUE, the new column value of a target table will be specified.
 

--- a/ko/sql/query/merge.rst
+++ b/ko/sql/query/merge.rst
@@ -6,12 +6,12 @@
 MERGE
 *****
 
-**MERGE** 문은 하나 또는 그 이상의 원본으로부터 행들을 선택하여 하나의 테이블 또는 뷰로 갱신이나 삽입을 수행하기 위해 사용되며, 대상 테이블 또는 뷰에 갱신할지 또는 삽입할지 결정하는 조건을 지정할 수 있다. **MERGE** 문은 결정적 문장(deterministic statement)으로, 하나의 문장 내에서 대상 테이블의 같은 행을 여러 번 갱신할 수 없다.
+**MERGE** 문은 하나의 원본으로부터 행들을 선택하여 하나의 테이블 또는 뷰로 갱신이나 삽입을 수행하기 위해 사용되며, 대상 테이블 또는 뷰에 갱신할지 또는 삽입할지 결정하는 조건을 지정할 수 있다. **MERGE** 문은 결정적 문장(deterministic statement)으로, 하나의 문장 내에서 대상 테이블의 같은 행을 여러 번 갱신할 수 없다.
 
 ::
 
     MERGE [<merge_hint>] INTO <target> [[AS] <alias>]
-    USING <source> [[AS] <alias>], <source> [[AS] <alias>], ...
+    USING <source> [[AS] <alias>]
     ON <join_condition>
     [ <merge_update_clause> ]
     [ <merge_insert_clause> ]
@@ -28,7 +28,7 @@ MERGE
     /*+ [ USE_UPDATE_IDX (<update_index_list>) ] [ USE_INSERT_IDX (<insert_index_list>) ] */
 
 *   <*target*>: 갱신하거나 삽입할 대상 테이블. 여러 개의 테이블 또는 뷰가 될 수 있다.
-*   <*source*>: 데이터를 가져올 원본 테이블. 여러 개의 테이블 또는 뷰가 될 수 있으며, 부질의(subquery)도 가능하다.
+*   <*source*>: 데이터를 가져올 원본 테이블. 하나의 테이블 또는 뷰가 될 수 있으며, 부질의(subquery)도 가능하다.
 *   <*join_condition*>: 갱신할 조건을 명시한다.
 *   <*merge_update_clause*>: <*join_condition*> 조건이 TRUE이면 대상 테이블의 새로운 칼럼 값들을 지정한다.
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-101

The MERGE statement has target specification and source specification and the target is single table and source is also single table or single subquery.

However, on the manual the source specification has multiple tables or multiple subqueries.

We should modify the manual to the source has single table or single subquery.