### PR TITLE
[CUBRIDMAN-51] add -u dba option at upgrade section.

### DIFF
--- a/en/sql/function/json_fn.rst
+++ b/en/sql/function/json_fn.rst
@@ -748,7 +748,7 @@ JSON_MERGE_PATCH
 .. function:: JSON_MERGE_PATCH (json_doc, json_doc [, json_doc] ...)
 
 The **JSON_MERGE_PATCH** function merges two or more json docs and returns the resulting merged json. **JSON_MERGE_PATCH** differs from **JSON_MERGE_PRESERVE** in that it will take the second argument when encountering merging conflicts. **JSON_MERGE_PATCH** is compliant with
-`RFC 7396 <https://tools.ietf.org/html/rfc7396/>`_.
+`RFC 7396 <https://www.rfc-editor.org/info/rfc7396>`_.
 
 The merging of two json documents is performed with the following rules, recursively:
 

--- a/en/upgrade.rst
+++ b/en/upgrade.rst
@@ -85,7 +85,7 @@ The following table shows how to perform the migration using the reserved word d
 |                                    | Execute the cubrid unloaddb utility and store the file generated at this point in a           |
 |                                    | separate directory (C3b).                                                                     |
 |                                    |                                                                                               |
-|                                    |   % cubrid unloaddb -S testdb                                                                 |
+|                                    |   % cubrid unloaddb -S -u dba testdb                                                          |
 |                                    |                                                                                               |
 |                                    | Delete the existing database (C3c).                                                           |
 |                                    |                                                                                               |
@@ -104,7 +104,7 @@ The following table shows how to perform the migration using the reserved word d
 |                                    |                                                                                               |
 |                                    | Execute the cubrid loaddb utility with the stored files in (C3b). (C5b)                       |
 |                                    |                                                                                               |
-|                                    |   % cubrid loaddb -s testdb_schema -d testdb_objects -i testdb_indexes testdb                 |
+|                                    |   % cubrid loaddb -u dba -s testdb_schema -d testdb_objects -i testdb_indexes testdb          |
 +------------------------------------+-----------------------------------------------------------------------------------------------+
 | Step C6: Back up the new version   |   % cubrid backupdb -S testdb                                                                 |
 |          of the DB                 |                                                                                               |

--- a/ko/sql/function/json_fn.rst
+++ b/ko/sql/function/json_fn.rst
@@ -738,7 +738,7 @@ JSON_MERGE_PATCH
 .. function:: JSON_MERGE_PATCH (json_doc, json_doc [, json_doc] ...)
 
 **JSON_MERGE_PATCH** 함수는 둘 이상의 json 문서를 병합하고 병합된 결과 json을 반환한다. **JSON_MERGE_PATCH** 는 병합 충돌 시 두 번째 인자를 사용하는 점에서 **JSON_MERGE_PRESERVE** 와 다르다. 
-**JSON_MERGE_PATCH** 함수는 `RFC 7396 <https://tools.ietf.org/html/rfc7396/>` 을 준수한다.
+**JSON_MERGE_PATCH** 함수는 `RFC 7396 <https://www.rfc-editor.org/info/rfc7396>` 을 준수한다.
 
 두 개의 json 문서 병합은 다음 규칙에 따라 재귀적으로 수행된다:
 

--- a/ko/upgrade.rst
+++ b/ko/upgrade.rst
@@ -85,7 +85,7 @@ DB 마이그레이션
 |                                    | cubrid unload 유틸리티를 실행하고 이 때 생성된 파일을 별도 디렉토리에 보관한다.(C3b)          |
 |                                    |                                                                                               |
 |                                    |                                                                                               |
-|                                    |   % cubrid unloaddb -S testdb                                                                 |
+|                                    |   % cubrid unloaddb -S -u dbatestdb                                                           |
 |                                    |                                                                                               |
 |                                    | 이전 DB 를 제거 한다. (C3c)                                                                   |
 |                                    |                                                                                               |
@@ -104,7 +104,7 @@ DB 마이그레이션
 |                                    |                                                                                               |
 |                                    | (C3b)에서 생성한 파일을 가지고cubrid loaddb 유틸리티를 실행한다. (C5b)                        |
 |                                    |                                                                                               |
-|                                    |   % cubrid loaddb -s testdb_schema -d testdb_objects -i testdb_indexes testdb                 |
+|                                    |   % cubrid loaddb -u dba -s testdb_schema -d testdb_objects -i testdb_indexes testdb          |
 +------------------------------------+-----------------------------------------------------------------------------------------------+
 | Step C6: 새 버전의 DB 백업         |   % cubrid backupdb -S testdb                                                                 |
 |                                    |                                                                                               |

--- a/ko/upgrade.rst
+++ b/ko/upgrade.rst
@@ -85,7 +85,7 @@ DB 마이그레이션
 |                                    | cubrid unload 유틸리티를 실행하고 이 때 생성된 파일을 별도 디렉토리에 보관한다.(C3b)          |
 |                                    |                                                                                               |
 |                                    |                                                                                               |
-|                                    |   % cubrid unloaddb -S -u dbatestdb                                                           |
+|                                    |   % cubrid unloaddb -S -u dba testdb                                                          |
 |                                    |                                                                                               |
 |                                    | 이전 DB 를 제거 한다. (C3c)                                                                   |
 |                                    |                                                                                               |


### PR DESCRIPTION
    http://jira.cubrid.org/browse/CUBRIDMAN-51

    The utility should be used with the -u dba option to avoid errors when users upgrade to v11.2 using unloaddb and loaddb.