### PR TITLE
[CUBRIDMAN-103] fix the position of the USING INDEX clause in the SELECT statement

### DIFF
--- a/en/sql/query/select.rst
+++ b/en/sql/query/select.rst
@@ -14,9 +14,9 @@ The **SELECT** statement specifies columns that you want to retrieve from a tabl
         [WHERE <search_condition>]
         [GROUP BY {col_name | expr} [ASC | DESC], ...[WITH ROLLUP]]
         [HAVING  <search_condition> ]
-        [ORDER BY {col_name | expr} [ASC | DESC], ... [NULLS {FIRST | LAST}]
-        [LIMIT [offset,] row_count]
         [USING INDEX { index_name [,index_name, ...] | NONE }]
+        [ORDER BY {col_name | expr} [ASC | DESC], ... [NULLS {FIRST | LAST}]
+        [LIMIT [offset,] row_count]        
         [FOR UPDATE [OF <spec_name_comma_list>]]
         
         <qualifier> ::= ALL | DISTINCT | DISTINCTROW | UNIQUE

--- a/ko/sql/query/select.rst
+++ b/ko/sql/query/select.rst
@@ -15,9 +15,9 @@ SELECT
         [WHERE <search_condition>]
         [GROUP BY {col_name | expr} [ASC | DESC], ...[WITH ROLLUP]]
         [HAVING  <search_condition> ]
-        [ORDER BY {col_name | expr} [ASC | DESC], ... [NULLS {FIRST | LAST}]
-        [LIMIT [offset,] row_count]
         [USING INDEX { index_name [,index_name, ...] | NONE }]
+        [ORDER BY {col_name | expr} [ASC | DESC], ... [NULLS {FIRST | LAST}]
+        [LIMIT [offset,] row_count]        
         [FOR UPDATE [OF <spec_name_comma_list>]]
         
         <qualifier> ::= ALL | DISTINCT | DISTINCTROW | UNIQUE


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-103

* The USING INDEX clause must come after the HAVING clause and before the ORDER BY clause
* Correct the representation of where USING INDEX can come from in the FROM clause.