### PR TITLE
[CUBRIDMAN-116] Correct the order of the CREATE INDEX syntax

### DIFF
--- a/en/sql/schema/index_stmt.rst
+++ b/en/sql/schema/index_stmt.rst
@@ -19,9 +19,9 @@ For how to use indexes on the **SELECT** statement like Using SQL Hint, Descendi
      
         <index_col_desc> ::=
             { ( column_name [ASC | DESC] [ {, column_name [ASC | DESC]} ...] ) [ WHERE <filter_predicate> ] | 
-            (function_name (argument_list) ) } 
-                { [[WITH ONLINE [PARALLEL parallel_count]] | [INVISIBLE] | [VISIBLE]] }
+            (function_name (argument_list) ) }
                 [COMMENT 'index_comment_string']
+                { [[WITH ONLINE [PARALLEL parallel_count]] | [INVISIBLE] | [VISIBLE]] }
 
 *   **UNIQUE**: creates an index with unique values.
 *   *index_name*: specifies the name of the index to be created. The index name must be unique in the table.

--- a/ko/sql/schema/index_stmt.rst
+++ b/ko/sql/schema/index_stmt.rst
@@ -21,8 +21,8 @@ CREATE INDEX
         <index_col_desc> ::=
             { ( column_name [ASC | DESC] [ {, column_name [ASC | DESC]} ...] ) [ WHERE <filter_predicate> ] |
             (function_name (argument_list) ) }
-                { [[WITH ONLINE [PARALLEL parallel_count]] | [INVISIBLE] | [VISIBLE]] }
                 [COMMENT 'index_comment_string']
+                { [[WITH ONLINE [PARALLEL parallel_count]] | [INVISIBLE] | [VISIBLE]] }
 
 *   **UNIQUE**: 유일한 값을 갖는 고유 인덱스를 생성한다.
 *   *index_name*: 생성하려는 인덱스의 이름을 명시한다. 인덱스 이름은 테이블 안에서 고유한 값이어야 한다.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-116

* Correct the order of the CREATE INDEX syntax

The order of the "WITH ONLINE" clause and the "COMMENT" clause in the definition of the CREATE INDEX clause is expressed incorrectly.
"COMMENT" must precede "WITH ONLINE", "VISIBLE" and "INVISIBLE".
