### PR TITLE
[CUBRIDMAN-117] Correct the CREATE TABLE syntax in the manual

### DIFF
--- a/en/sql/schema/table_stmt.rst
+++ b/en/sql/schema/table_stmt.rst
@@ -21,7 +21,7 @@ To create a table, use the **CREATE TABLE** statement.
     CREATE {TABLE | CLASS} [IF NOT EXISTS] [schema_name.]table_name
     [<subclass_definition>]
     [CLASS ATTRIBUTE (<column_definition>, ...)]
-    [([{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...])]
+    [([{<table_constraint>}... ,] <column_definition> [{, {<column_definition> | <table_constraint>}}...])]
     [INHERIT <resolution>, ...]
     [<table_options>]
 
@@ -889,7 +889,7 @@ You can create a new table that contains the result records of the **SELECT** st
 
 ::
 
-    CREATE {TABLE | CLASS} [schema_name.]table_name [([{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...])] [REPLACE] AS <select_statement>;
+    CREATE {TABLE | CLASS} [schema_name.]table_name [([{<table_constraint>}... ,] <column_definition> [{, {<column_definition> | <table_constraint>}}...])] [REPLACE] AS <select_statement>;
 
 *   *schema_name*: Specifies the schema name. If omitted, the schema name of the current session is used.
 *   *table_name*: a name of the table to be created.

--- a/en/sql/schema/table_stmt.rst
+++ b/en/sql/schema/table_stmt.rst
@@ -21,7 +21,7 @@ To create a table, use the **CREATE TABLE** statement.
     CREATE {TABLE | CLASS} [IF NOT EXISTS] [schema_name.]table_name
     [<subclass_definition>]
     [CLASS ATTRIBUTE (<column_definition>, ...)]
-    [{[{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...]}]
+    [([{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...])]
     [INHERIT <resolution>, ...]
     [<table_options>]
 
@@ -889,7 +889,7 @@ You can create a new table that contains the result records of the **SELECT** st
 
 ::
 
-    CREATE {TABLE | CLASS} [schema_name.]table_name [{[{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...]}] [REPLACE] AS <select_statement>;
+    CREATE {TABLE | CLASS} [schema_name.]table_name [([{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...])] [REPLACE] AS <select_statement>;
 
 *   *schema_name*: Specifies the schema name. If omitted, the schema name of the current session is used.
 *   *table_name*: a name of the table to be created.

--- a/en/sql/schema/table_stmt.rst
+++ b/en/sql/schema/table_stmt.rst
@@ -20,9 +20,8 @@ To create a table, use the **CREATE TABLE** statement.
 
     CREATE {TABLE | CLASS} [IF NOT EXISTS] [schema_name.]table_name
     [<subclass_definition>]
-    [(<column_definition>, ... [, <table_constraint>, ...])] 
-    [AUTO_INCREMENT = initial_value]
     [CLASS ATTRIBUTE (<column_definition>, ...)]
+    [{[{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...]}]
     [INHERIT <resolution>, ...]
     [<table_options>]
 
@@ -80,7 +79,8 @@ To create a table, use the **CREATE TABLE** statement.
             <table_option> ::= REUSE_OID | DONT_REUSE_OID |
                                COMMENT [=] 'table_comment_string' |
                                [CHARSET charset_name] [COLLATE collation_name] |
-                               ENCRYPT [=] [AES | ARIA]
+                               ENCRYPT [=] [AES | ARIA] |
+                               AUTO_INCREMENT = initial_value
 
 *   IF NOT EXISTS: If an identically named table already exists, a new table will not be created without an error.
 *   *schema_name*: Specifies the schema name(maximum: 31 bytes). If omitted, the schema name of the current session is used.
@@ -889,7 +889,7 @@ You can create a new table that contains the result records of the **SELECT** st
 
 ::
 
-    CREATE {TABLE | CLASS} [schema_name.]table_name [(<column_definition> [,<table_constraint>], ...)] [REPLACE] AS <select_statement>;
+    CREATE {TABLE | CLASS} [schema_name.]table_name [{[{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...]}] [REPLACE] AS <select_statement>;
 
 *   *schema_name*: Specifies the schema name. If omitted, the schema name of the current session is used.
 *   *table_name*: a name of the table to be created.

--- a/ko/sql/schema/table_stmt.rst
+++ b/ko/sql/schema/table_stmt.rst
@@ -21,7 +21,7 @@ CREATE TABLE
     CREATE {TABLE | CLASS} [IF NOT EXISTS] [schema_name.]table_name
     [<subclass_definition>]
     [CLASS ATTRIBUTE (<column_definition>, ...)]
-    [{[{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...]}]
+    [([{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...])]
     [INHERIT <resolution>, ...]
     [<table_options>]
 
@@ -889,7 +889,7 @@ CREATE TABLE AS SELECT
 
 ::
 
-    CREATE {TABLE | CLASS} [schema_name.]table_name [{[{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...]}] [COMMENT [=] 'comment_string'] [REPLACE] AS <select_statement>;
+    CREATE {TABLE | CLASS} [schema_name.]table_name [([{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...])] [COMMENT [=] 'comment_string'] [REPLACE] AS <select_statement>;
 
 *   *schema_name*: 스키마 이름을 지정한다. 생략하면 현재 세션의 스키마 이름을 사용한다.
 *   *table_name*: 새로 생성할 테이블 이름이다.

--- a/ko/sql/schema/table_stmt.rst
+++ b/ko/sql/schema/table_stmt.rst
@@ -21,7 +21,7 @@ CREATE TABLE
     CREATE {TABLE | CLASS} [IF NOT EXISTS] [schema_name.]table_name
     [<subclass_definition>]
     [CLASS ATTRIBUTE (<column_definition>, ...)]
-    [([{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...])]
+    [([{<table_constraint>}... ,] <column_definition> [{, {<column_definition> | <table_constraint>}}...])]
     [INHERIT <resolution>, ...]
     [<table_options>]
 
@@ -889,7 +889,7 @@ CREATE TABLE AS SELECT
 
 ::
 
-    CREATE {TABLE | CLASS} [schema_name.]table_name [([{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...])] [COMMENT [=] 'comment_string'] [REPLACE] AS <select_statement>;
+    CREATE {TABLE | CLASS} [schema_name.]table_name [([{<table_constraint>}... ,] <column_definition> [{ ,{<column_definition> | <table_constraint>}}...])] [COMMENT [=] 'comment_string'] [REPLACE] AS <select_statement>;
 
 *   *schema_name*: 스키마 이름을 지정한다. 생략하면 현재 세션의 스키마 이름을 사용한다.
 *   *table_name*: 새로 생성할 테이블 이름이다.

--- a/ko/sql/schema/table_stmt.rst
+++ b/ko/sql/schema/table_stmt.rst
@@ -20,9 +20,8 @@ CREATE TABLE
 
     CREATE {TABLE | CLASS} [IF NOT EXISTS] [schema_name.]table_name
     [<subclass_definition>]
-    [(<column_definition>, ... [, <table_constraint>, ...])] 
-    [AUTO_INCREMENT = initial_value]
     [CLASS ATTRIBUTE (<column_definition>, ...)]
+    [{[{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...]}]
     [INHERIT <resolution>, ...]
     [<table_options>]
 
@@ -80,7 +79,8 @@ CREATE TABLE
             <table_option> ::= REUSE_OID | DONT_REUSE_OID |
                                COMMENT [=] 'table_comment_string' |
                                [CHARSET charset_name] [COLLATE collation_name] |
-                               ENCRYPT [=] [AES | ARIA]
+                               ENCRYPT [=] [AES | ARIA] | 
+                               AUTO_INCREMENT = initial_value
 
 *   **IF NOT EXISTS**: 생성하려는 테이블이 존재하는 경우 에러 없이 테이블을 생성하지 않는다.
 *   *schema_name*: 스키마 이름을 지정한다(최대 31바이트). 생략하면 현재 세션의 스키마 이름을 사용한다.
@@ -889,7 +889,7 @@ CREATE TABLE AS SELECT
 
 ::
 
-    CREATE {TABLE | CLASS} [schema_name.]table_name [(<column_definition> [,<table_constraint>], ...)] [COMMENT [=] 'comment_string'] [REPLACE] AS <select_statement>;
+    CREATE {TABLE | CLASS} [schema_name.]table_name [{[{<table_constraint>}... ,] <column_definition> [{,{<column_definition>|<table_constraint>}}...]}] [COMMENT [=] 'comment_string'] [REPLACE] AS <select_statement>;
 
 *   *schema_name*: 스키마 이름을 지정한다. 생략하면 현재 세션의 스키마 이름을 사용한다.
 *   *table_name*: 새로 생성할 테이블 이름이다.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-117

Correct the incorrect parts of the syntax description on the manual page, such as ordering errors.

The "CLASS ATTRIBUTE" clause must precede the usual column_definition.
Also, "AUTO_INCREMENT = initial_value" should be included in <table_options>.
Modify the combination of column definition and constraint specification syntax.