### PR TITLE
[CUBRIDMAN-138] Modify manual description related to group_concat_max_len

### DIFF
--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -1203,7 +1203,7 @@ The following are parameters related to SQL statements and data types supported 
 +---------------------------------+--------+------------+------------+------------+
 | default_week_format             | int    | 0          |            |            |
 +---------------------------------+--------+------------+------------+------------+
-| group_concat_max_len            | byte   | 1,024      | 4          | 33,554,432 |
+| group_concat_max_len            | byte   | 1,024      | 4          | INT_MAX    |
 +---------------------------------+--------+------------+------------+------------+
 | intl_check_input_string         | bool   | no         |            |            |
 +---------------------------------+--------+------------+------------+------------+
@@ -1324,7 +1324,7 @@ The following are parameters related to SQL statements and data types supported 
 **group_concat_max_len**
 
     **group_concat_max_len** is a parameter used to limit the return value size of the :func:`GROUP_CONCAT` function.
-    You can set a unit as B, K, M, G or T, which stands for bytes, kilobytes(KB), megabytes(MB), gigabytes(GB) or terabytes(TB) respectively. If you omit the unit, bytes will be applied. The default value is **1,024**. The minimum value is 4 and the maximum value is 33,554,432 bytes. 
+    You can set a unit as B, K, M, G or T, which stands for bytes, kilobytes(KB), megabytes(MB), gigabytes(GB) or terabytes(TB) respectively. If you omit the unit, bytes will be applied. The default value is **1,024**. The minimum value is 4 and the maximum value is INT_MAX (about 2G) bytes. 
     
     This function is affected by **string_max_size_bytes** parameter; if the value of **group_concat_max_len** is greater than the value **string_max_size_bytes** and the result size of **GROUP_CONCAT** exceeds the value of **string_max_size_bytes**, an error occurs.
 

--- a/en/sql/function/analysis_fn.rst
+++ b/en/sql/function/analysis_fn.rst
@@ -652,7 +652,7 @@ GROUP_CONCAT
     :param SEPARATOR: Specifies the separator to divide the result values. If it is omitted, the default character, comma (,) will be used as a separator.
     :rtype: STRING
 
-The maximum size of the return value follows the configuration of the system parameter, **group_concat_max_len**. The default is **1024** bytes, the minimum value is 4 bytes and the maximum value is 33,554,432 bytes.
+The maximum size of the return value follows the configuration of the system parameter, **group_concat_max_len**. The default is **1024** bytes, the minimum value is 4 bytes and the maximum value is IN_MAX(about 2G) bytes.
 
 This function is affected by **string_max_size_bytes** parameter; if the value of **group_concat_max_len** is larger than the value **string_max_size_bytes** and the result size of **GROUP_CONCAT** exceeds the value of **string_max_size_bytes**, an error occurs.
 

--- a/ko/admin/config.rst
+++ b/ko/admin/config.rst
@@ -1200,7 +1200,7 @@ CUBRID 설치 시 생성되는 기본 데이터베이스 환경 설정 파일(**
 +---------------------------------+--------+------------+------------+------------+
 | default_week_format             | int    | 0          |            |            |
 +---------------------------------+--------+------------+------------+------------+
-| group_concat_max_len            | byte   | 1,024      | 4          | 33,554,432 |
+| group_concat_max_len            | byte   | 1,024      | 4          | INT_MAX    |
 +---------------------------------+--------+------------+------------+------------+
 | intl_check_input_string         | bool   | no         |            |            |
 +---------------------------------+--------+------------+------------+------------+
@@ -1315,9 +1315,9 @@ CUBRID 설치 시 생성되는 기본 데이터베이스 환경 설정 파일(**
 **group_concat_max_len**
 
     **group_concat_max_len**  은 :func:`GROUP_CONCAT` 함수의 리턴 값의 크기를 제한하는 파라미터이다.
-    값 뒤에 B, K, M, G, T로 단위를 붙일 수 있으며, 각각 Bytes, Kilobytes, Megabytes, Gigabytes, Terabytes를 의미한다. 단위를 생략하면 바이트 단위가 적용된다. 기본값은 **1,024** 바이트이며, 최소값은 4 바이트, 최대값은 33,554,432 바이트이다. :func:`GROUP_CONCAT` 함수의 결과가 제한을 넘으면 오류가 반환된다.
+    값 뒤에 B, K, M, G, T로 단위를 붙일 수 있으며, 각각 Bytes, Kilobytes, Megabytes, Gigabytes, Terabytes를 의미한다. 단위를 생략하면 바이트 단위가 적용된다. 기본값은 **1,024** 바이트이며, 최소값은 4 바이트, 최대값은INT_MAX 바이트(약2G)이다. :func:`GROUP_CONCAT` 함수의 결과가 제한을 넘으면 오류가 반환된다.
 
-    이 함수는 **string_max_size_bytes** 파라미터의 영향을 받으며, **string_max_size_bytes** 보다 **group_concat_max_len** 이 크고 :func:`GROUP_CONCAT` 함수의 결과가 **string_max_size_bytes** 의 크기 제한을 넘으면 오류가 반환된다.
+    이 함수는 **string_max_size_bytes** 파라미터의 영향을 받으며, **group_concat_max_len** 값을 **string_max_size_bytes** 보다 크게 설정한 경우 :func:`GROUP_CONCAT` 결과가 **string_max_size_bytes** 값을 초과하면 오루가 발생한다.
 
 **intl_check_input_string**
 

--- a/ko/admin/config.rst
+++ b/ko/admin/config.rst
@@ -1317,7 +1317,7 @@ CUBRID 설치 시 생성되는 기본 데이터베이스 환경 설정 파일(**
     **group_concat_max_len**  은 :func:`GROUP_CONCAT` 함수의 리턴 값의 크기를 제한하는 파라미터이다.
     값 뒤에 B, K, M, G, T로 단위를 붙일 수 있으며, 각각 Bytes, Kilobytes, Megabytes, Gigabytes, Terabytes를 의미한다. 단위를 생략하면 바이트 단위가 적용된다. 기본값은 **1,024** 바이트이며, 최소값은 4 바이트, 최대값은INT_MAX 바이트(약2G)이다. :func:`GROUP_CONCAT` 함수의 결과가 제한을 넘으면 오류가 반환된다.
 
-    이 함수는 **string_max_size_bytes** 파라미터의 영향을 받으며, **group_concat_max_len** 값을 **string_max_size_bytes** 보다 크게 설정한 경우 :func:`GROUP_CONCAT` 결과가 **string_max_size_bytes** 값을 초과하면 오루가 발생한다.
+    이 함수는 **string_max_size_bytes** 파라미터의 영향을 받으며, **group_concat_max_len** 값을 **string_max_size_bytes** 보다 크게 설정한 경우 :func:`GROUP_CONCAT` 결과가 **string_max_size_bytes** 값을 초과하면 오류가 발생한다.
 
 **intl_check_input_string**
 

--- a/ko/sql/function/analysis_fn.rst
+++ b/ko/sql/function/analysis_fn.rst
@@ -653,9 +653,9 @@ GROUP_CONCAT
     :param SEPARATOR: 결과 값 사이에 구분할 구분자를 지정한다. 생략하면 기본값인 쉼표(,)를 구분자로 사용한다.
     :rtype: STRING
 
-리턴 값의 최대 크기는 시스템 파라미터 **group_concat_max_len** 의 설정을 따른다. 기본값은 **1024** 바이트이며, 최소값은 4바이트, 최대값은 33,554,432바이트이다.
+리턴 값의 최대 크기는 시스템 파라미터 **group_concat_max_len** 의 설정을 따른다. 기본값은 **1024** 바이트이며, 최소값은 4바이트, 최대값은 INT_MAX(약2G)바이트이다.
 
-이 함수는 **string_max_size_bytes** 파라미터의 영향을 받는데,  **group_concat_max_len**\의 값이 **string_max_size_bytes**\의 값보다 크고 **GROUP_CONCAT** 함수의 결과가 **string_max_size_bytes**\의 크기 제한을 넘으면 오류가 반환된다.
+이 함수는 **string_max_size_bytes** 파라미터의 영향을 받으며,  **group_concat_max_len**\의 값을 **string_max_size_bytes** 보다 크게 설정한 경우 **GROUP_CONCAT** 결과가 **string_max_size_bytes** 값을 초과하면 오류가 발생한다.
 
 중복되는 값을 제거하려면 **DISTINCT** 절을 사용하면 된다. 그룹 결과의 값 사이에 사용되는 기본 구분자는 쉼표(,)이며, 구분자를 명시적으로 표현하려면 **SEPARATOR** 절과 그 뒤에 구분자로 사용할 문자열을 추가한다. 구분자를 제거하려면 **SEPARATOR** 절 뒤에 빈 문자열(empty string)을 입력한다.
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-138

need to modification for readability:

The Korean version of the below English description:

This function is affected by string_max_size_bytes parameter; if the value of group_concat_max_len is larger than the value string_max_size_bytes and the result size of GROUP_CONCAT exceeds the value of string_max_size_bytes, an error occurs.