### PR TITLE
[CUBRIDMAN-108] Add item to restrictions of dblink

### DIFF
--- a/en/sql/dblink.rst
+++ b/en/sql/dblink.rst
@@ -575,7 +575,7 @@ Restrictions
 *   The maximum string length of one column is supported up to 16M.
 *   When using cache in Mysql, it is recommended to use PREFETCH, NO_CACHE=1 because the memory usage of the gateway cub_cas_cgw increases.
 *   ODBC non-supported types are SQL_INTERVAL, SQL_GUID, SQL_BIT, SQL_BINARY, SQL_VARBINARY, SQL_LONGVARBINARY.
-*   When using DBLink between heterogeneous types (Oracle/MySQL), you must use Oracle/MySQL's Unicode dedicated ODBC driver.
+*   When using DBLink with heterogeneous types (Oracle/MySQL), you must use Oracle/MySQL's Unicode ODBC driver.
 
 
 

--- a/en/sql/dblink.rst
+++ b/en/sql/dblink.rst
@@ -575,7 +575,7 @@ Restrictions
 *   The maximum string length of one column is supported up to 16M.
 *   When using cache in Mysql, it is recommended to use PREFETCH, NO_CACHE=1 because the memory usage of the gateway cub_cas_cgw increases.
 *   ODBC non-supported types are SQL_INTERVAL, SQL_GUID, SQL_BIT, SQL_BINARY, SQL_VARBINARY, SQL_LONGVARBINARY.
-
+*   When using DBLink between heterogeneous types (Oracle/MySQL), you must use Oracle/MySQL's Unicode dedicated ODBC driver.
 
 
 

--- a/ko/sql/dblink.rst
+++ b/ko/sql/dblink.rst
@@ -589,7 +589,7 @@ DBLink을 사용하기 위해 연결할 CUBRID의 broker들 정보 파악 또는
 *   1개 컬럼의 문자열 최대 길이는 16M까지만 지원한다.
 *   Mysql에서 cache를 사용하는 경우 게이트웨이 cub_cas_cgw의 메모리 사용량이 증가하므로 PREFETCH, NO_CACHE=1 사용을 권장한다.
 *   ODBC 미지원 타입은 SQL_INTERVAL,SQL_GUID,SQL_BIT,SQL_BINARY,SQL_VARBINARY,SQL_LONGVARBINARY 이다.
-
+*   이기종(Oracle/MySQL)간 DBLink 사용시 반드시 Oracle/MySQL의 유니코드 전용 ODBC Drvier를 사용해야 한다.
 
 
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-108

Purpose
Add the following to the constraints
* When using DBLink between heterogeneous types (Oracle/MySQL), you must use Oracle/MySQL's Unicode dedicated ODBC driver.

Implementation
N/A

Remarks
N/A