### PR TITLE
[CUBRIDMAN-155] Prevent schema loading with loaddb in HA Mode.

### DIFF
--- a/en/admin/migration.inc
+++ b/en/admin/migration.inc
@@ -290,7 +290,7 @@ The following table shows [options] available with the **cubrid loaddb** utility
 
 .. note::
 
-    In **client-server** mode (-C, \-\-CS-MODE), only the -d option (data loading) is available.
+    When in **HA** (High Availability) mode, in **client-server** mode (-C, \-\-CS-MODE), only the -d option (data loading) is available.
 
 .. option:: --data-file-check-only
 

--- a/en/admin/migration.inc
+++ b/en/admin/migration.inc
@@ -290,7 +290,7 @@ The following table shows [options] available with the **cubrid loaddb** utility
 
 .. note::
 
-    When in **HA** (High Availability) mode, in **client-server** mode (-C, \-\-CS-MODE), only the -d option (data loading) is available.
+    When in **client-server** mode (-C, \-\-CS-MODE) on the **HA** (High Availability), only the -d option (data loading) is available.
 
 .. option:: --data-file-check-only
 

--- a/ko/admin/migration.inc
+++ b/ko/admin/migration.inc
@@ -289,7 +289,7 @@ loaddb
 
 .. note::
 
-    **client-server** 모드(-C, \-\-CS-MODE)에서는 -d 옵션(data loading)만 사용 가능하다.
+    **HA** (High Availability) 모드 일때, **client-server** 모드(-C, \-\-CS-MODE)에서는 -d 옵션(data loading)만 사용 가능하다.
 
 .. option:: --data-file-check-only
 

--- a/ko/admin/migration.inc
+++ b/ko/admin/migration.inc
@@ -289,7 +289,7 @@ loaddb
 
 .. note::
 
-    **HA** (High Availability) 모드 일때, **client-server** 모드(-C, \-\-CS-MODE)에서는 -d 옵션(data loading)만 사용 가능하다.
+    **HA** (High Availability)환경의 **client-server** 모드(-C, \-\-CS-MODE)에서는 -d 옵션(data loading)만 사용 가능하다.
 
 .. option:: --data-file-check-only
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-155

Purpose
Add restrictions on the use of loaddb in HA mode.
Add the following content to the -C --CS option description of loaddb
* When in client-server mode (-C, --CS-MODE) on the HA (High Availability), only the -d option (data loading) is available.

Implementation
N/A

Remarks
N/A