### PR TITLE
[CUBRIDMAN-158] Added description of how to specify schema name in class name when writing object file for load

### DIFF
--- a/en/admin/migration.inc
+++ b/en/admin/migration.inc
@@ -522,7 +522,7 @@ A command line begins with a percent character (%) and consists of **%class** an
         %id [project] 23
         %id [phone] 24
 
-    The *schema_name* and *class_name* must be enclosed in square brackets ([ ]). The *schema_name* and *class_name* can be enclosed in square brackets individually or together in square brackets.
+    The *schema_name* and *class_name* must be enclosed in square brackets ([ ]). Each of *schema_name* and *class_name* or together can be enclosed in square brackets .
 
     ::
 
@@ -606,18 +606,18 @@ Data for each attribute must be separated by at least one space and be basically
             [schema_name.]class_name
             class_id
 
-    Specify a class name or a class id after the **@** sign, and an instance number after a vertical line (|). Spaces are not allowed before and after a vertical line (|). The method of wirting *class_ref* is the same as the method of wirting *schema_name* and *class_name* in the :ref:`Command Line <howtowrite-loadfile-command-line>`.
+    Specify a class name or a class id after the **@** sign, and an instance number after a vertical line (|). Spaces are not allowed before and after a vertical line (|). The method of wirting *class_ref* is the same as the method of wirting *schema_name* and *class_name* in the :ref:`Command Line <howtowrite-loadfile-command-line>`. However, enclosing each of *schema_name* and *class_name* in square brackets ([ ]) is not allowed.
 
     The following example shows how to load class instances into the *paycheck* class. The *name* attribute references an instance of the *employee* class. As in the last line, data is loaded as **NULL** if you configure the reference relation by using an instance number not specified earlier.
     
     ::
 
         %class [public].[paycheck] (name department salary)
-        @[public].[employee]|1   'planning'   8000000   
-        @[public].[employee]|2   'planning'   6000000  
-        @[public].[employee]|3   'sales'   5000000  
-        @[public].[employee]|4   'development'   4000000
-        @[public].[employee]|5   'development'   5000000
+        @[public.employee]|1   'planning'   8000000   
+        @[public.employee]|2   'planning'   6000000  
+        @[public.employee]|3   'sales'   5000000  
+        @[public.employee]|4   'development'   4000000
+        @[public.employee]|5   'development'   5000000
 
     Since the id 21 was assigned to the *employee* class by using the **%id** command in the :ref:`Assigning an Identifier to a Class <assign-id-to-class>` section, the above example can be written as follows:
     

--- a/en/admin/migration.inc
+++ b/en/admin/migration.inc
@@ -489,6 +489,8 @@ In CUBRID, a comment is represented by two hyphens (\-\-). ::
 
     -- This is a comment!
 
+.. _howtowrite-loadfile-command-line:
+
 Command Line
 ++++++++++++
 
@@ -498,15 +500,36 @@ A command line begins with a percent character (%) and consists of **%class** an
 
 *   Assigning an Identifier to a Class
 
-    You can assign an identifier to class reference relations by using the **%id** command. ::
+    You can assign an identifier to class reference relations by using the **%id** command.
+    
+    ::
 
-        %id class_name class_id
+        %id [schema_name.]class_name class_id
+        schema_name:
+            identifier
         class_name:
             identifier
         class_id:
             integer
 
-    The *class_name* specified by the **%id** command is the class name defined in the database, and *class_id* is the numeric identifier which is assigned for object reference. The **class_name** must be prefixed with the schema name and enclosed in square brackets ([ ]).
+    The *class_name* specified by the **%id** command is the class name defined in the database, and *class_id* is the numeric identifier which is assigned for object reference. The *class_name* uses the *schema_name* as a prefix and the *schema_name* is the name of the schema in which the class is defined.
+    The *schema_name* can be omitted, and if the *schema_name* is omitted, the user name of the database specified with the -u option is used as the schema name.
+
+    ::
+
+        %id [employee] 21
+        %id [office] 22
+        %id [project] 23
+        %id [phone] 24
+
+    The *schema_name* and *class_name* must be enclosed in square brackets ([ ]). The *schema_name* and *class_name* can be enclosed in square brackets individually or together in square brackets.
+
+    ::
+
+        %id [public].[employee] 21
+        %id [public].[office] 22
+        %id [public].[project] 23
+        %id [public].[phone] 24
 
     ::
 
@@ -517,17 +540,27 @@ A command line begins with a percent character (%) and consists of **%class** an
 
 *   Specifying the Class and Attribute
 
-    You can specify the classes (tables) and attributes (columns) upon loading data by using the **%class** command. The data line should be written based on the order of attributes specified. When a class name is provided by using the **-t** option while executing the **cubrid loaddb** utility, you don't have to specify the class and attribute in the data file. However, the order of writing data must comply with the order of the attribute defined when creating a class. ::
+    You can specify the classes (tables) and attributes (columns) upon loading data by using the **%class** command. The data line should be written based on the order of attributes specified. When a class name is provided by using the **-t** option while executing the **cubrid loaddb** utility, you don't have to specify the class and attribute in the data file. However, the order of writing data must comply with the order of the attribute defined when creating a class.
+    
+    ::
 
-        %class [schema_name.class_name] ( attr_name [attr_name... ] )
+        %class [schema_name.]class_name (attr_name [attr_name...])
+        schema_name:
+            identifier
+        class_name:
+            identifier
+        attr_name:
+            identifier
 
-    The schema must be pre-defined in the database to be loaded.
+    The class must be pre-defined in the database to be loaded.
 
-    The *class_name* specified by the **%class** command is the class name defined in the database and the *attr_name* is the name of the attribute defined. The class name must be prefixed with the schema name and enclosed in square brackets ([ ]).
+    The *class_name* specified by the **%class** command is the class name defined in the database and the *schema_name* is the name of the schema in which the class is defined. The *attr_name* is the name of the attribute defined. The method of writing *schema_name* and *class_name* is the same as above.
 
-    The following example shows how to specify a class and three attributes by using the **%class** command to enter data into a class named *employee*. Three pieces of data should be entered on the data lines after the **%class** command. For this, see :ref:`Configuring Reference Relation <conf-reference-relation>`. ::
+    The following example shows how to specify a class and three attributes by using the **%class** command to enter data into a class named *employee*. Three pieces of data should be entered on the data lines after the **%class** command. For this, see :ref:`Configuring Reference Relation <conf-reference-relation>`.
+    
+    ::
 
-        %class [public.employee] (name age department)
+        %class [public].[employee] (name age department)
 
 Data Line
 +++++++++
@@ -542,7 +575,7 @@ Data for each attribute must be separated by at least one space and be basically
 
     ::
 
-        %class [public.employee] (name)
+        %class [public].[employee] (name)
         'jordan' 
         'james'  
         'garnett'
@@ -554,7 +587,7 @@ Data for each attribute must be separated by at least one space and be basically
 
     ::
 
-        %class [public.employee] (name)
+        %class [public].[employee] (name)
         1: 'jordan' 
         2: 'james'  
         3: 'garnett' 
@@ -564,27 +597,33 @@ Data for each attribute must be separated by at least one space and be basically
     
 *   Configuring Reference Relation
 
-    You can configure the object reference relation by specifying the reference class after an "at sign (**@**)" and the instance number after the "vertical line (|)." ::
+    You can configure the object reference relation by specifying the reference class after an "at sign (**@**)" and the instance number after the "vertical line (|)."
+    
+    ::
 
         @class_ref | instance_no
         class_ref:
-             class_name
-             class_id
+            [schema_name.]class_name
+            class_id
 
-    Specify a class name or a class id after the **@** sign, and an instance number after a vertical line (|). Spaces are not allowed before and after a vertical line (|). The table name must be prefixed with the schema name.
+    Specify a class name or a class id after the **@** sign, and an instance number after a vertical line (|). Spaces are not allowed before and after a vertical line (|). The method of wirting *class_ref* is the same as the method of wirting *schema_name* and *class_name* in the :ref:`Command Line <howtowrite-loadfile-command-line>`.
 
-    The following example shows how to load class instances into the *paycheck* class. The *name* attribute references an instance of the *employee* class. As in the last line, data is loaded as **NULL** if you configure the reference relation by using an instance number not specified earlier. ::
+    The following example shows how to load class instances into the *paycheck* class. The *name* attribute references an instance of the *employee* class. As in the last line, data is loaded as **NULL** if you configure the reference relation by using an instance number not specified earlier.
+    
+    ::
 
-        %class [public.paycheck] (name department salary)
-        @[public.employee]|1   'planning'   8000000   
-        @[public.employee]|2   'planning'   6000000  
-        @[public.employee]|3   'sales'   5000000  
-        @[public.employee]|4   'development'   4000000
-        @[public.employee]|5   'development'   5000000
+        %class [public].[paycheck] (name department salary)
+        @[public].[employee]|1   'planning'   8000000   
+        @[public].[employee]|2   'planning'   6000000  
+        @[public].[employee]|3   'sales'   5000000  
+        @[public].[employee]|4   'development'   4000000
+        @[public].[employee]|5   'development'   5000000
 
-    Since the id 21 was assigned to the *employee* class by using the **%id** command in the :ref:`Assigning an Identifier to a Class <assign-id-to-class>` section, the above example can be written as follows: ::
+    Since the id 21 was assigned to the *employee* class by using the **%id** command in the :ref:`Assigning an Identifier to a Class <assign-id-to-class>` section, the above example can be written as follows:
+    
+    ::
 
-        %class [public.paycheck] (name department salary)
+        %class [public].[paycheck] (name department salary)
         @21|1   'planning'   8000000   
         @21|2   'planning'   6000000  
         @21|3   'sales'   5000000  

--- a/en/admin/migration.inc
+++ b/en/admin/migration.inc
@@ -522,7 +522,7 @@ A command line begins with a percent character (%) and consists of **%class** an
         %id [project] 23
         %id [phone] 24
 
-    The *schema_name* and *class_name* must be enclosed in square brackets ([ ]). Each of *schema_name* and *class_name* or together can be enclosed in square brackets .
+    The *schema_name* and *class_name* must be enclosed in square brackets ([ ]). Each of *schema_name* and *class_name* or together can be enclosed in square brackets.
 
     ::
 

--- a/en/sql/dblink.rst
+++ b/en/sql/dblink.rst
@@ -61,7 +61,7 @@ cub_cas_cgw (CAS Gateway) acts as a common application server used by all the ap
 cub_gateway
 ----------------
 
-cub_gateway mediates the connection between the application client and the cub_cas_cgw. That is, when an application client requests access, the cub_broker checks the status of the cub_cas_cgw through the shared memory, and then delivers the request to an accessible cub_cas_cgw . It then returns the processing results of the request from the cub_cas_cgw to the application client.
+cub_gateway mediates the connection between the application client and the cub_cas_cgw. That is, when an application client requests access, the cub_broker checks the status of the cub_cas_cgw through the shared memory, and then delivers the request to an accessible cub_cas_cgws. It then returns the processing results of the request from the cub_cas_cgw to the application client.
 
 The cub_gateway also manages the server load by adjusting the number of cub_cas_cgw (s) in the service pool and monitors and manages the status of the cub_cas_cgw. If the cub_gateway delivers the request to cub_cas_cgw but the connection to cub_cas_cgw 1 fails because of an abnormal termination, it sends an error message about the connection failure to the application client and restarts cub_cas_cgw 1. Restarted cub_cas_cgw 1 is now in a normal stand-by mode, and will be reconnected by a new request from a new application client.
 

--- a/en/sql/query/select.rst
+++ b/en/sql/query/select.rst
@@ -761,7 +761,7 @@ An outer join is divided into a left outer join which outputs all rows of the le
 *   <*join_table_specification2*>
 
     *   **CROSS JOIN**: Used for cross join and requires no join conditions.
-    *   **NATURAL** [**LEFT** | **RIGHT**] **JOIN**: Used for natural join and join condition is not used. It operates in the equivalent same way to have a condition between columns equivalent of the same name .
+    *   **NATURAL** [**LEFT** | **RIGHT**] **JOIN**: Used for natural join and join condition is not used. It operates in the equivalent same way to have a condition between columns equivalent of the same name.
 
 Inner Join
 ----------

--- a/en/sql/tuning.rst
+++ b/en/sql/tuning.rst
@@ -408,7 +408,7 @@ In the above example, under lines of "Trace Statistics:" are the result of traci
 
 *   **SELECT** (time: 1, fetch: 975, ioread: 2)
     
-    *   time: 4 => Total query time took 4ms. 
+    *   time: 1 => Total query time took 4ms. 
     *   fetch: 975 => 975 times were fetched regarding pages. (not the number of pages, but the count of accessing pages. even if the same pages are fetched, the count is increased.).
     *   ioread: disk accessed 2 times.
 

--- a/en/sql/tuning.rst
+++ b/en/sql/tuning.rst
@@ -408,7 +408,7 @@ In the above example, under lines of "Trace Statistics:" are the result of traci
 
 *   **SELECT** (time: 1, fetch: 975, ioread: 2)
     
-    *   time: 1 => Total query time took 4ms. 
+    *   time: 1 => Total query time took 1ms. 
     *   fetch: 975 => 975 times were fetched regarding pages. (not the number of pages, but the count of accessing pages. even if the same pages are fetched, the count is increased.).
     *   ioread: disk accessed 2 times.
 

--- a/ko/admin/migration.inc
+++ b/ko/admin/migration.inc
@@ -519,7 +519,7 @@ CUBRID에서는 주석은 두 개의 연속된 하이픈(\-\-)을 이용하여 �
         %id [project] 23
         %id [phone] 24
 
-    *schema_name*\과 *class_name*\은 대괄호([ ])로 묶어야 한다. *schema_name*\과 *class_name*\은 개별로 대괄호([ ])로 묶거나, 함께 대괄호([ ])로 묶을 수 있다.
+    *schema_name*\과 *class_name*\은 대괄호([ ])로 묶어야 한다. *schema_name*\과 *class_name*\의 각각을 대괄호로 묶거나, 함께 대괄호로 묶을 수 있다.
 
     ::
 
@@ -600,21 +600,21 @@ CUBRID에서는 주석은 두 개의 연속된 하이픈(\-\-)을 이용하여 �
 
         @class_ref | instance_no
         class_ref:
-             [schema_name.]class_name
+             class_name
              class_id
 
-    **@** 다음에는 클래스명 또는 클래스 id를 명시하고, 수직바(|) 다음에는 인스턴스 번호를 명시한다. 수직바(|)의 양쪽에는 공백을 허용하지 않는다. *class_ref*\의 작성 방법은 :ref:`명령 라인 <howtowrite-loadfile-command-line>`\의 *schema_name*\과 *class_name*\의 작성 방법과 동일하다.
+    **@** 다음에는 클래스명 또는 클래스 id를 명시하고, 수직바(|) 다음에는 인스턴스 번호를 명시한다. 수직바(|)의 양쪽에는 공백을 허용하지 않는다. *class_ref*\의 작성 방법은 :ref:`명령 라인 <howtowrite-loadfile-command-line>`\의 *schema_name*\과 *class_name*\의 작성 방법과 동일하다. 하지만 *schema_name*\과 *class_name* 각각을 대괄호([ ])로 묶는 것은 허용하지 않는다.
 
     다음은 *paycheck* 클래스에 인스턴스를 입력하는 예제이며, *name* 속성은 *employee* 클래스의 인스턴스를 참조한다. 마지막 라인과 같이 앞에서 정의되지 아니한 인스턴스 번호를 이용하여 참조 관계를 설정하는 경우 해당 데이터는 **NULL** 로 입력된다.
     
     ::
 
         %class [public].[paycheck] (name department salary)
-        @[public].[employee]|1   'planning'   8000000   
-        @[public].[employee]|2   'planning'   6000000  
-        @[public].[employee]|3   'sales'   5000000  
-        @[public].[employee]|4   'development'   4000000
-        @[public].[employee]|5   'development'   5000000
+        @[public.employee]|1   'planning'   8000000   
+        @[public.employee]|2   'planning'   6000000  
+        @[public.employee]|3   'sales'   5000000  
+        @[public.employee]|4   'development'   4000000
+        @[public.employee]|5   'development'   5000000
 
     :ref:`클래스에 식별자 부여 <assign-id-to-class>`\ 에서 **%id** 명령어로 *employee* 클래스에 21이라는 식별자를 부여했으므로, 위의 예를 다음과 같이 작성할 수 있다.
     

--- a/ko/admin/migration.inc
+++ b/ko/admin/migration.inc
@@ -486,6 +486,8 @@ CUBRID에서는 주석은 두 개의 연속된 하이픈(\-\-)을 이용하여 �
 
     -- This is a comment!
 
+.. _howtowrite-loadfile-command-line:
+
 명령 라인
 +++++++++
 
@@ -495,15 +497,36 @@ CUBRID에서는 주석은 두 개의 연속된 하이픈(\-\-)을 이용하여 �
 
 *   클래스에 식별자 부여
 
-    **%id** 를 이용하여 참조 관계에 있는 클래스에 식별자를 부여할 수 있다. ::
+    **%id** 를 이용하여 참조 관계에 있는 클래스에 식별자를 부여할 수 있다.
+    
+    ::
 
-        %id class_name class_id
+        %id [schema_name.]class_name class_id
+        schema_name:
+            identifier
         class_name:
             identifier
         class_id:
             integer
 
-    **%id** 명령어에 의해 명시된 *class_name* 은 해당 데이터베이스에 정의된 클래스 이름이며, *class_id* 는 객체 참조를 위해 부여한 숫자형 식별자를 의미한다. 클래스 이름은 스키마 이름을 접두사로 사용하고, 대괄호([ ])로 묶어야 한다.
+    **%id** 명령어에 의해 명시된 *class_name*\은 해당 데이터베이스에 정의된 클래스 이름이다. *class_name*\은 *schema_name*\을 접두사로 사용하며, *schema_name*\은 클래스가 정의된 스키마 이름이다.
+    *schema_name*\은 생략힐 수 있으며, *schema_name*\을 생략하면 -u 옵션과 함께 지정된 데이터베이스의 사용자 이름이 스키마 이름으로 사용된다.
+
+    ::
+
+        %id [employee] 21
+        %id [office] 22
+        %id [project] 23
+        %id [phone] 24
+
+    *schema_name*\과 *class_name*\은 대괄호([ ])로 묶어야 한다. *schema_name*\과 *class_name*\은 개별로 대괄호([ ])로 묶거나, 함께 대괄호([ ])로 묶을 수 있다.
+
+    ::
+
+        %id [public].[employee] 21
+        %id [public].[office] 22
+        %id [public].[project] 23
+        %id [public].[phone] 24
 
     ::
 
@@ -514,17 +537,27 @@ CUBRID에서는 주석은 두 개의 연속된 하이픈(\-\-)을 이용하여 �
 
 *   클래스 및 속성 명시
 
-    **%class** 명령어를 이용하여 데이터가 로딩될 클래스(테이블) 및 속성(칼럼)을 명시하며, 명시된 속성의 순서에 따라 데이터 라인이 작성되어야 한다. **cubrid loaddb** 유틸리티를 실행할 때 **-t** 옵션으로 클래스 이름을 제공하는 경우에는 데이터 파일에 클래스 및 속성을 명시하지 않아도 된다. 단, 데이터가 작성되는 순서는 클래스 생성 시의 속성 순서를 따라야 한다. ::
+    **%class** 명령어를 이용하여 데이터가 로딩될 클래스(테이블) 및 속성(칼럼)을 명시하며, 명시된 속성의 순서에 따라 데이터 라인이 작성되어야 한다. **cubrid loaddb** 유틸리티를 실행할 때 **-t** 옵션으로 클래스 이름을 제공하는 경우에는 데이터 파일에 클래스 및 속성을 명시하지 않아도 된다. 단, 데이터가 작성되는 순서는 클래스 생성 시의 속성 순서를 따라야 한다.
+    
+    ::
 
-    %class [schema_name.class_name] ( attr_name [attr_name... ] )
+        %class [schema_name.]class_name (attr_name [attr_name...])
+        schema_name:
+            identifier
+        class_name:
+            identifier
+        attr_name:
+            identifier
 
-데이터를 로딩하고자 하는 데이터베이스에는 이미 스키마가 정의되어 있어야 한다.
+    데이터를 로딩하고자 하는 데이터베이스에는 클래스가 이미 정의되어 있어야 한다.
 
-**%class** 명령어에 의해 명시된 *class_name* 은 해당 데이터베이스에 정의된 클래스 이름이며, *attr_name* 는 정의된 속성 이름을 의미한다. 클래스 이름은 스키마 이름을 접두사로 사용하고, 대괄호([ ])로 감싸야 한다.
+    **%class** 명령어에 의해 명시된 *class_name*\은 해당 데이터베이스에 정의된 클래스 이름이며, *schema_name*\은 클래스가 정의된 스키마 이름이다. *attr_name*\는 정의된 속성 이름을 의미한다. *schema_name*\과 *class_name*\의 작성 방법은 위와 동일하다.
 
-다음은 *employee* 라는 클래스에 데이터를 입력하기 위하여 **%class** 명령으로 클래스 및 3개의 속성을 명시한 예제이다. **%class** 명령 다음에 나오는 데이터 라인에서는 3개의 데이터가 입력되어야 하며, 이는 :ref:`참조 관계 설정 <conf-reference-relation>`\을 참조한다. ::
+    다음은 *employee*\라는 클래스에 데이터를 입력하기 위하여 **%class** 명령으로 클래스 및 3개의 속성을 명시한 예제이다. **%class** 명령 다음에 나오는 데이터 라인에서는 3개의 데이터가 입력되어야 하며, 이는 :ref:`참조 관계 설정 <conf-reference-relation>`\을 참조한다.
+    
+    ::
 
-    %class [public.employee] (name age department)
+        %class [public].[employee] (name age department)
 
 데이터 라인
 +++++++++++
@@ -539,7 +572,7 @@ CUBRID에서는 주석은 두 개의 연속된 하이픈(\-\-)을 이용하여 �
 
     ::
 
-        %class [public.employee] (name)
+        %class [public].[employee] (name)
         'jordan' 
         'james'  
         'garnett'
@@ -551,7 +584,7 @@ CUBRID에서는 주석은 두 개의 연속된 하이픈(\-\-)을 이용하여 �
 
     ::
 
-        %class [public.employee] (name)
+        %class [public].[employee] (name)
         1: 'jordan' 
         2: 'james'  
         3: 'garnett' 
@@ -561,27 +594,33 @@ CUBRID에서는 주석은 두 개의 연속된 하이픈(\-\-)을 이용하여 �
     
 *   참조 관계 설정
 
-    **@** 다음에 참조하는 클래스를 명시하고, 수직바(|) 다음에 참조하는 인스턴스의 번호를 명시하여 객체 참조 관계를 설정할 수 있다. ::
+    **@** 다음에 참조하는 클래스를 명시하고, 수직바(|) 다음에 참조하는 인스턴스의 번호를 명시하여 객체 참조 관계를 설정할 수 있다.
+    
+    ::
 
         @class_ref | instance_no
         class_ref:
-             class_name
+             [schema_name.]class_name
              class_id
 
-    **@** 다음에는 클래스명 또는 클래스 id를 명시하고, 수직바(|) 다음에는 인스턴스 번호를 명시한다. 수직바(|)의 양쪽에는 공백을 허용하지 않는다. 테이블 이름은 스키마 이름을 접두사로 사용해야 한다.
+    **@** 다음에는 클래스명 또는 클래스 id를 명시하고, 수직바(|) 다음에는 인스턴스 번호를 명시한다. 수직바(|)의 양쪽에는 공백을 허용하지 않는다. *class_ref*\의 작성 방법은 :ref:`명령 라인 <howtowrite-loadfile-command-line>`\의 *schema_name*\과 *class_name*\의 작성 방법과 동일하다.
 
-    다음은 *paycheck* 클래스에 인스턴스를 입력하는 예제이며, *name* 속성은 *employee* 클래스의 인스턴스를 참조한다. 마지막 라인과 같이 앞에서 정의되지 아니한 인스턴스 번호를 이용하여 참조 관계를 설정하는 경우 해당 데이터는 **NULL** 로 입력된다. ::
+    다음은 *paycheck* 클래스에 인스턴스를 입력하는 예제이며, *name* 속성은 *employee* 클래스의 인스턴스를 참조한다. 마지막 라인과 같이 앞에서 정의되지 아니한 인스턴스 번호를 이용하여 참조 관계를 설정하는 경우 해당 데이터는 **NULL** 로 입력된다.
+    
+    ::
 
-        %class [public.paycheck] (name department salary)
-        @[public.employee]|1   'planning'   8000000   
-        @[public.employee]|2   'planning'   6000000  
-        @[public.employee]|3   'sales'   5000000  
-        @[public.employee]|4   'development'   4000000
-        @[public.employee]|5   'development'   5000000
+        %class [public].[paycheck] (name department salary)
+        @[public].[employee]|1   'planning'   8000000   
+        @[public].[employee]|2   'planning'   6000000  
+        @[public].[employee]|3   'sales'   5000000  
+        @[public].[employee]|4   'development'   4000000
+        @[public].[employee]|5   'development'   5000000
 
-    :ref:`클래스에 식별자 부여 <assign-id-to-class>`\ 에서 **%id** 명령어로 *employee* 클래스에 21이라는 식별자를 부여했으므로, 위의 예를 다음과 같이 작성할 수 있다. ::
+    :ref:`클래스에 식별자 부여 <assign-id-to-class>`\ 에서 **%id** 명령어로 *employee* 클래스에 21이라는 식별자를 부여했으므로, 위의 예를 다음과 같이 작성할 수 있다.
+    
+    ::
 
-        %class [public.paycheck] (name department salary)
+        %class [public].[paycheck] (name department salary)
         @21|1   'planning'   8000000   
         @21|2   'planning'   6000000  
         @21|3   'sales'   5000000  

--- a/ko/sql/tuning.rst
+++ b/ko/sql/tuning.rst
@@ -409,7 +409,7 @@ SQL에 대한 성능 분석을 위해서는 질의 프로파일링(profiling) �
 
 *   **SELECT** (time: 1, fetch: 975, ioread: 2) 
     
-    *   time: 4 => 전체 질의 시간 4ms 소요. 
+    *   time: 1 => 전체 질의 시간 4ms 소요. 
     *   fetch: 975 => 페이지에 대해 975회 fetch(개수가 아닌 접근 회수임. 같은 페이지를 다시 fetch하더라도 회수가 증가함). 
     *   ioread: 2회 디스크 접근.
 

--- a/ko/sql/tuning.rst
+++ b/ko/sql/tuning.rst
@@ -409,7 +409,7 @@ SQL에 대한 성능 분석을 위해서는 질의 프로파일링(profiling) �
 
 *   **SELECT** (time: 1, fetch: 975, ioread: 2) 
     
-    *   time: 1 => 전체 질의 시간 4ms 소요. 
+    *   time: 1 => 전체 질의 시간 1ms 소요. 
     *   fetch: 975 => 페이지에 대해 975회 fetch(개수가 아닌 접근 회수임. 같은 페이지를 다시 fetch하더라도 회수가 증가함). 
     *   ioread: 2회 디스크 접근.
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-158
http://jira.cubrid.org/browse/CBRD-24609
http://jira.cubrid.org/browse/CBRD-24468

### Added description of how to specify schema name in class name when writing object file for load
- The class name uses the schema name as a prefix and the schema name is the name of the schema in which the class is defined.
- The schema name can be omitted, and if the schema name is omitted, the user name of the database specified with the -u option is used as the schema name.
- The schema name and class name must be enclosed in square brackets ([ ]). The schema name and class name can be enclosed in square brackets individually or together in square brackets.