### PR TITLE
[CUBRIDMAN-160] Migration of dictionary iteration methods to Python 3

### DIFF
--- a/en/_templates_org/layout.html
+++ b/en/_templates_org/layout.html
@@ -60,10 +60,10 @@
       {% set my_keys = title + ', ' + docstitle %}
       {% set my_desc = title + ' &mdash; ' + docstitle + '.' %}
       {% if meta is defined %}
-        {% if 'meta-keywords' in meta.viewkeys() %}
+        {% if 'meta-keywords' in meta.keys() %}
           {% set my_keys = my_keys + ', ' + meta.get('meta-keywords') %}
         {% endif %}
-        {%if 'meta-description' in meta.viewkeys() %}
+        {%if 'meta-description' in meta.keys() %}
           {% set my_desc = my_desc + ' ' + meta.get('meta-description') %}
         {% endif %}
       {% endif %}

--- a/ko/_templates_org/layout.html
+++ b/ko/_templates_org/layout.html
@@ -60,10 +60,10 @@
       {% set my_keys = title + ', ' + docstitle %}
       {% set my_desc = title + ' &mdash; ' + docstitle + '.' %}
       {% if meta is defined %}
-        {% if 'meta-keywords' in meta.viewkeys() %}
+        {% if 'meta-keywords' in meta.keys() %}
           {% set my_keys = my_keys + ', ' + meta.get('meta-keywords') %}
         {% endif %}
-        {%if 'meta-description' in meta.viewkeys() %}
+        {%if 'meta-description' in meta.keys() %}
           {% set my_desc = my_desc + ' ' + meta.get('meta-description') %}
         {% endif %}
       {% endif %}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-160

The dict.viewkeys is possible in python 2.
So it should be converted to keys() in python 3.