### PR TITLE
[CUBRIDMAN-163] Make codeowner file for automatically assigning default reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,11 @@
 #   limitations under the License.
 # 
 
-# required reviewer for korean manual
+# assign reviewers about all files
+* @mhoh3963 @ssihil
+
+# required reviewers for korean manual
 /ko/ @mhoh3963 @ssihil
 
-# required reviewer for english manual
+# required reviewers for english manual
 /en/ @mhoh3963 @ssihil @sunggc-cubrid

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,4 +22,4 @@
 /ko/ @mhoh3963 @ssihil
 
 # required reviewers for english manual
-/en/ @mhoh3963 @ssihil @sunggc-cubrid
+/en/ @mhoh3963 @ssihil @sungc-cubrid

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+#
+#
+#  Copyright 2016 CUBRID Corporation
+# 
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+# 
+#       http://www.apache.org/licenses/LICENSE-2.0
+# 
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+# 
+
+# required reviewer for korean manual
+/ko/ @mhoh3963 @ssihil
+
+# required reviewer for english manual
+/en/ @mhoh3963 @ssihil @sunggc-cubrid


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-163

The manual projects don't have verification procedures other than peer reviews, so it is important to prevent errors as much as possible by reinforcing essential reviewers.
Therefore, we will make codeowner file at .github for automatically designating required reviewers.