### PR TITLE
[CUBRIDMAN-165] Change csql formatter download link

### DIFF
--- a/en/csql.rst
+++ b/en/csql.rst
@@ -1422,7 +1422,7 @@ This command specifies the formatter to be used with **;EDIT** session command. 
 
         The use of Free SQL Formatter is recommended.
 
-        Download URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.tar
+        Download URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.tar.gz
 
 **Specifying the editor (;EDITOR_Cmd)**
 

--- a/en/csql.rst
+++ b/en/csql.rst
@@ -1422,7 +1422,7 @@ This command specifies the formatter to be used with **;EDIT** session command. 
 
         The use of Free SQL Formatter is recommended.
 
-        Download URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.0.0-csql.1/fsqlf-1.0.0.csql.1.gz
+        Download URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.gz
 
 **Specifying the editor (;EDITOR_Cmd)**
 

--- a/en/csql.rst
+++ b/en/csql.rst
@@ -1422,7 +1422,7 @@ This command specifies the formatter to be used with **;EDIT** session command. 
 
         The use of Free SQL Formatter is recommended.
 
-        Download URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.gz
+        Download URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.tar
 
 **Specifying the editor (;EDITOR_Cmd)**
 

--- a/ko/csql.rst
+++ b/ko/csql.rst
@@ -1422,7 +1422,7 @@ CSQL 인터프리터에서 작업 중인 데이터베이스 이름 및 호스트
     
         Free SQL Formatter 사용을 권고합니다.
 
-        다운로드 URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.0.0-csql.1/fsqlf-1.0.0.csql.1.gz
+        다운로드 URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.gz
 
 **편집기 설정(;EDITOR_Cmd)**
 

--- a/ko/csql.rst
+++ b/ko/csql.rst
@@ -1422,7 +1422,7 @@ CSQL 인터프리터에서 작업 중인 데이터베이스 이름 및 호스트
     
         Free SQL Formatter 사용을 권고합니다.
 
-        다운로드 URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.tar
+        다운로드 URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.tar.gz
 
 **편집기 설정(;EDITOR_Cmd)**
 

--- a/ko/csql.rst
+++ b/ko/csql.rst
@@ -1422,7 +1422,7 @@ CSQL 인터프리터에서 작업 중인 데이터베이스 이름 및 호스트
     
         Free SQL Formatter 사용을 권고합니다.
 
-        다운로드 URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.gz
+        다운로드 URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.tar
 
 **편집기 설정(;EDITOR_Cmd)**
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-165

The download link address of csql formatter has been changed, so modifying the manual.

ko url : http://192.168.2.57/ko/csql.html#cmdoption-csql-arg-format
en url : http://192.168.2.57/en/csql.html#cmdoption-csql-arg-format