### PR TITLE
[CUBRIDMAN-146] Added file names generated when using the --split-schema-files option

### DIFF
--- a/en/admin/migration.inc
+++ b/en/admin/migration.inc
@@ -190,15 +190,16 @@ The following is [options] used in **cubrid unloaddb**.
     List of files created by spliting schema information into object units ::
 	
         demodb_schema_user
-		demodb_schema_class
-		demodb_schema_vclass
-		demodb_schema_serial
-		demodb_schema_procedure
-		demodb_schema_server
-		demodb_schema_pk
-		demodb_schema_fk
-		demodb_schema_grant
-		demodb_schema_synonym
+        demodb_schema_class
+        demodb_schema_vclass
+        demodb_schema_synonym
+        demodb_schema_vclass_query_spec
+        demodb_schema_serial
+        demodb_schema_procedure
+        demodb_schema_server
+        demodb_schema_pk
+        demodb_schema_fk
+        demodb_schema_grant
 
     Filename containing a list of splited schema files
     

--- a/ko/admin/migration.inc
+++ b/ko/admin/migration.inc
@@ -191,13 +191,14 @@ unloaddb
 		demodb_schema_user
 		demodb_schema_class
 		demodb_schema_vclass
+		demodb_schema_synonym
+		demodb_schema_vclass_query_spec
 		demodb_schema_serial
 		demodb_schema_procedure
 		demodb_schema_server
 		demodb_schema_pk
 		demodb_schema_fk
 		demodb_schema_grant
-		demodb_schema_synonym
 
     분할된 스키마 파일들의 목록을 가지고 있는 파일명
     

--- a/ko/admin/migration.inc
+++ b/ko/admin/migration.inc
@@ -188,17 +188,17 @@ unloaddb
 
     스키마 정보를 오브젝트 단위로 분할하여 생성한 파일 목록 ::
 
-		demodb_schema_user
-		demodb_schema_class
-		demodb_schema_vclass
-		demodb_schema_synonym
-		demodb_schema_vclass_query_spec
-		demodb_schema_serial
-		demodb_schema_procedure
-		demodb_schema_server
-		demodb_schema_pk
-		demodb_schema_fk
-		demodb_schema_grant
+        demodb_schema_user
+        demodb_schema_class
+        demodb_schema_vclass
+        demodb_schema_synonym
+        demodb_schema_vclass_query_spec
+        demodb_schema_serial
+        demodb_schema_procedure
+        demodb_schema_server
+        demodb_schema_pk
+        demodb_schema_fk
+        demodb_schema_grant
 
     분할된 스키마 파일들의 목록을 가지고 있는 파일명
     


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-146

Purpose
Added a list of files generated by using the "--split-schema-files" option

demodb_schema_user
demodb_schema_class
demodb_schema_vclass
demodb_schema_synonym
**demodb_schema_vclass_query_spec**
demodb_schema_serial
demodb_schema_procedure
demodb_schema_server
demodb_schema_pk
demodb_schema_fk
demodb_schema_grant

Implementation
N/A

Remarks
N/A