### PR TITLE
[CUBRIDMAN-183] Remove CUBRIDDriver.getDefaultConnection() (#423)

### DIFF
--- a/en/sql/jsp.rst
+++ b/en/sql/jsp.rst
@@ -331,17 +331,11 @@ Creating Connection
 ---------------------
 
 To access the database from a Java stored function/procedure, you must use the server-side JDBC driver.
-To acquire a connection to the database using the server-side JDBC driver, you can either use "**jdbc:default:connection:**" as the URL for JDBC connection, or call the **getDefaultConnection** () method of the **cubrid.jdbc.driver.CUBRIDDriver** class.
+To acquire a connection to the database using the server-side JDBC driver, you can either use "**jdbc:default:connection:**" as the URL for JDBC connection.
 
 .. code-block:: java
 
     Connection conn = DriverManager.getConnection("jdbc:default:connection:");
-
-or
-
-.. code-block:: java
-
-    Connection conn = cubrid.jdbc.driver.CUBRIDDriver.getDefaultConnection();
 
 .. note::
 

--- a/en/sql/jsp.rst
+++ b/en/sql/jsp.rst
@@ -331,7 +331,7 @@ Creating Connection
 ---------------------
 
 To access the database from a Java stored function/procedure, you must use the server-side JDBC driver.
-To acquire a connection to the database using the server-side JDBC driver, you can either use "**jdbc:default:connection:**" as the URL for JDBC connection.
+To acquire a connection to the database using the server-side JDBC driver, you can use "**jdbc:default:connection:**" as the URL for JDBC connection.
 
 .. code-block:: java
 

--- a/ko/sql/jsp.rst
+++ b/ko/sql/jsp.rst
@@ -329,19 +329,12 @@ Connection 생성
 ----------------
 
 데이터베이스에 접근하기 위해서 서버 측 JDBC Connection을 생성해야한다.
-서버 측 JDBC 드라이버로 해당 데이터베이스의 Connection을 얻는 방법은 아래와 같다.
-첫 번째 방법은 JDBC 연결 URL로 "**jdbc:default:connection:**" 을 사용하는 것이고, 
-두 번째는 **cubrid.jdbc.driver.CUBRIDDriver** 클래스의 **getDefaultConnection** () 메서드를 호출하는 것이다.
+서버 측 JDBC 드라이버로 해당 데이터베이스의 Connection을 얻는 방법은 아래와 같이
+JDBC 연결 URL로 "**jdbc:default:connection:**" 을 사용한다.
 
 .. code-block:: java
 
     Connection conn = DriverManager.getConnection("jdbc:default:connection:");
-
-또는
-
-.. code-block:: java
-
-    Connection conn = cubrid.jdbc.driver.CUBRIDDriver.getDefaultConnection();
 
 .. note::
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-183

We don't support CUBRIDDriver.getDefaultConnection() anymore.

backport of #423 