### PR TITLE
[CUBRIDMAN-190] Remove meaningless zeros after the decimal point in double/float type

### DIFF
--- a/en/api/cciapi.rst
+++ b/en/api/cciapi.rst
@@ -908,7 +908,7 @@ cci_connect_with_url
         --connection URL string when useSSL property specified for encrypted connection
         URL = "cci:cubrid:192.168.0.1:33000:demodb:::?useSSL=true
 
-        --connection URL string when oracleStyleNumberReturn property is specified for remove decimal zeros from the result value
+        --connection URL string when oracleStyleNumberReturn property is specified to remove trailing zeros after the decimal point from the result value
         URL = "cci:cubrid:192.168.0.1:33000:demodb:::?oracleStyleNumberReturn=true
 
     .. warning::

--- a/en/api/cciapi.rst
+++ b/en/api/cciapi.rst
@@ -892,7 +892,7 @@ cci_connect_with_url
        *   Packet encryption: useSSL = true
        *   Plain text: useSSL = false
 
-    *   **oracleStyleNumberReturn**: If oracleStyleNumberReturn is true, zeros after the decimal point are removed from double and float type results. If it is false, zeros after the decimal point are not removed.
+    *   **oracleStyleNumberReturn**: If oracleStyleNumberReturn is true, trailing zeros after the decimal point are removed from double and float type results (eg. 0.12). If it is false, trailing zeros after the decimal point are not removed (eg. 0.1200000)
 
     **Example** ::
 

--- a/en/api/cciapi.rst
+++ b/en/api/cciapi.rst
@@ -845,7 +845,8 @@ cci_connect_with_url
                      | logSlowQueries=true|false[&slowQueryThresholdMillis=<milli_sec>]
                      | logTraceApi=true|false
                      | logTraceNetwork=true|false
-                     | useSSL=<bool_type>
+                     | useSSL=true|false
+                     | oracleStyleNumberReturn=true|false
          
         <alternative_hosts> ::= <host>:<port> [,<host>:<port>]
          
@@ -891,6 +892,8 @@ cci_connect_with_url
        *   Packet encryption: useSSL = true
        *   Plain text: useSSL = false
 
+    *   **oracleStyleNumberReturn**: If oracleStyleNumberReturn is true, zeros after the decimal point are removed from double and float type results. If it is false, zeros after the decimal point are not removed.
+
     **Example** ::
 
         --connection URL string when a property(altHosts) is specified for HA
@@ -904,6 +907,9 @@ cci_connect_with_url
 
         --connection URL string when useSSL property specified for encrypted connection
         URL = "cci:cubrid:192.168.0.1:33000:demodb:::?useSSL=true
+
+        --connection URL string when oracleStyleNumberReturn property is specified for remove decimal zeros from the result value
+        URL = "cci:cubrid:192.168.0.1:33000:demodb:::?oracleStyleNumberReturn=true
 
     .. warning::
 

--- a/en/api/jdbc.rst
+++ b/en/api/jdbc.rst
@@ -245,9 +245,9 @@ The **getConnection** method returns the **Connection** object and it is used to
     --connection URL string when hold_cursor property specified for cursor holdability
     URL=jdbc:CUBRID:192.168.0.1:33000:demodb:public::?hold_cursor=true    
 
-    --connection URL string when oracleStyleNumberReturn property is specified for remove decimal zeros from the result value 
-    URL = "cci:cubrid:192.168.0.1:33000:demodb:::?oracleStyleNumberReturn=true
-	
+    --connection URL string when oracleStyleNumberReturn property is specified to remove trailing zeros after the decimal point from the result value
+    URL=jdbc:CUBRID:192.168.0.1:33000:demodb:public::?oracleStyleNumberReturn=true
+
 **Example 2**
 
 .. code-block:: java

--- a/en/api/jdbc.rst
+++ b/en/api/jdbc.rst
@@ -143,7 +143,8 @@ The **getConnection** method returns the **Connection** object and it is used to
                  | usePreparedStmtCache=<bool_type>
                  | preparedStmtCacheSize=<unit_size>
                  | preparedStmtCacheSqlLimit=<unit_size>
-                 | hold_cursor=<bool_type>		 
+                 | hold_cursor=<bool_type>
+                 | oracleStyleNumberReturn=<bool_type>
 
         <alternative_hosts> ::=
         <standby_broker1_host>:<port> [,<standby_broker2_host>:<port>]
@@ -204,7 +205,7 @@ The **getConnection** method returns the **Connection** object and it is used to
     *  **preparedStmtCacheSize**: If usePreparedStmtCache is TRUE, the number of SQLs that can be cached (Default:25, Min:1, Max:2147483647)
     *  **preparedStmtCacheSqlLimit**: If usePreparedStmtCache is TRUE, length of SQL that can be cached (Default:256, Min:1, Max:2147483647)
     *  **hold_cursor**: Cursor holdability setting (default: true). If this value is false, CLOSE_CURSORS_AT_COMMIT is set, and if true, HOLD_CURSORS_OVER_COMMIT is set. For details, see :ref:`cursor-holding`\ .
-
+    *  **oracleStyleNumberReturn**: If oracleStyleNumberReturn is true, zeros after the decimal point are removed from double and float type results. If it is false, zeros after the decimal point are not removed.
 
 **Example 1** ::
 
@@ -244,6 +245,9 @@ The **getConnection** method returns the **Connection** object and it is used to
     --connection URL string when hold_cursor property specified for cursor holdability
     URL=jdbc:CUBRID:192.168.0.1:33000:demodb:public::?hold_cursor=true    
 
+    --connection URL string when oracleStyleNumberReturn property is specified for remove decimal zeros from the result value 
+    URL = "cci:cubrid:192.168.0.1:33000:demodb:::?oracleStyleNumberReturn=true
+	
 **Example 2**
 
 .. code-block:: java

--- a/en/api/jdbc.rst
+++ b/en/api/jdbc.rst
@@ -205,7 +205,7 @@ The **getConnection** method returns the **Connection** object and it is used to
     *  **preparedStmtCacheSize**: If usePreparedStmtCache is TRUE, the number of SQLs that can be cached (Default:25, Min:1, Max:2147483647)
     *  **preparedStmtCacheSqlLimit**: If usePreparedStmtCache is TRUE, length of SQL that can be cached (Default:256, Min:1, Max:2147483647)
     *  **hold_cursor**: Cursor holdability setting (default: true). If this value is false, CLOSE_CURSORS_AT_COMMIT is set, and if true, HOLD_CURSORS_OVER_COMMIT is set. For details, see :ref:`cursor-holding`\ .
-    *  **oracleStyleNumberReturn**: If oracleStyleNumberReturn is true, zeros after the decimal point are removed from double and float type results. If it is false, zeros after the decimal point are not removed.
+    *  **oracleStyleNumberReturn**: If oracleStyleNumberReturn is true, trailing zeros after the decimal point are removed from double and float type results (eg. 0.12). If it is false, trailing zeros after the decimal point are not removed (eg. 0.1200000)
 
 **Example 1** ::
 

--- a/ko/api/cciapi.rst
+++ b/ko/api/cciapi.rst
@@ -845,7 +845,8 @@ cci_connect_with_url
                      | logSlowQueries=true|false[&slowQueryThresholdMillis=<milli_sec>]
                      | logTraceApi=true|false
                      | logTraceNetwork=true|false
-                     | useSSL=<bool_type>
+                     | useSSL=true|false
+                     | oracleStyleNumberReturn=true|false
 
         <alternative_hosts> ::= <host>:<port> [,<host>:<port>]
          
@@ -891,6 +892,8 @@ cci_connect_with_url
        *   패킷 암호화: useSSL = true
        *   일반 평문: useSSL = false
 
+    *   **oracleStyleNumberReturn**: oracleStyleNumberReturn가 true인 경우, double, float 타입의 결과 값에서 소수점 이하의 0을 제거, false이면 소수점 이하 0을 제거하지 않는다.
+	
     **예제** ::
 
         --connection URL string when a property(altHosts) is specified for HA
@@ -904,6 +907,9 @@ cci_connect_with_url
 
         --connection URL string when useSSL property specified for encrypted connection
         URL = "cci:cubrid:192.168.0.1:33000:demodb:::?useSSL=true
+		
+        --connection URL string when oracleStyleNumberReturn property is specified for remove decimal zeros from the result value
+        URL = "cci:cubrid:192.168.0.1:33000:demodb:::?oracleStyleNumberReturn=true
 
     .. warning::
 

--- a/ko/api/cciapi.rst
+++ b/ko/api/cciapi.rst
@@ -892,7 +892,7 @@ cci_connect_with_url
        *   패킷 암호화: useSSL = true
        *   일반 평문: useSSL = false
 
-    *   **oracleStyleNumberReturn**: oracleStyleNumberReturn가 true인 경우, double, float 타입의 결과 값에서 소수점 이하의 0을 제거, false이면 소수점 이하 0을 제거하지 않는다.
+    *   **oracleStyleNumberReturn**: oracleStyleNumberReturn가 true인 경우, double, float 타입의 결과 값에서 소수점 이하의 후행 0을 억제 (예: 0.12), false이면 후행 0가 그대로 표시된다 (예: 0.12000000)
 	
     **예제** ::
 

--- a/ko/api/cciapi.rst
+++ b/ko/api/cciapi.rst
@@ -908,7 +908,7 @@ cci_connect_with_url
         --connection URL string when useSSL property specified for encrypted connection
         URL = "cci:cubrid:192.168.0.1:33000:demodb:::?useSSL=true
 		
-        --connection URL string when oracleStyleNumberReturn property is specified for remove decimal zeros from the result value
+        --connection URL string when oracleStyleNumberReturn property is specified to remove trailing zeros after the decimal point from the result value
         URL = "cci:cubrid:192.168.0.1:33000:demodb:::?oracleStyleNumberReturn=true
 
     .. warning::

--- a/ko/api/jdbc.rst
+++ b/ko/api/jdbc.rst
@@ -245,7 +245,7 @@ JDBC 프로그래밍
     --connection URL string when hold_cursor property specified for cursor holdability
     URL=jdbc:CUBRID:192.168.0.1:33000:demodb:public::?hold_cursor=true
 	
-    --connection URL string when oracleStyleNumberReturn property is specified for remove decimal zeros from the result value
+    --connection URL string when oracleStyleNumberReturn property is specified to remove trailing zeros after the decimal point from the result value
     URL=jdbc:CUBRID:192.168.0.1:33000:demodb:public::?oracleStyleNumberReturn=true
 
 **예제 2**

--- a/ko/api/jdbc.rst
+++ b/ko/api/jdbc.rst
@@ -143,7 +143,8 @@ JDBC 프로그래밍
                  | usePreparedStmtCache=<bool_type>
                  | preparedStmtCacheSize=<unit_size>
                  | preparedStmtCacheSqlLimit=<unit_size>
-                 | hold_cursor=<bool_type>				 
+                 | hold_cursor=<bool_type>
+                 | oracleStyleNumberReturn=<bool_type>					
 
         <alternative_hosts> ::=
         <standby_broker1_host>:<port> [,<standby_broker2_host>:<port>]
@@ -204,6 +205,7 @@ JDBC 프로그래밍
     *  **preparedStmtCacheSize**: usePreparedStmtCache가 TRUE일 경우, 캐싱할 수 있는 갯수  (기본:25, 최소:1, 최대:2147483647)
     *  **preparedStmtCacheSqlLimit**: usePreparedStmtCache가 TRUE일 경우, 캐싱할 수 있는 SQL의 길이 (기본:256, 최소:1, 최대:2147483647)
     *  **hold_cursor**: 커서 유지 기능 설정(기본값: true). 이 값이 false 이면 CLOSE_CURSORS_AT_COMMIT이 설정되고, true 이면 HOLD_CURSORS_OVER_COMMIT이 설정된다. 자세한 내용은 :ref:`cursor-holding`\ 을 참고한다.
+    *  **oracleStyleNumberReturn**: oracleStyleNumberReturn가 true인 경우, double, float 타입의 결과 값에서 소수점 이하의 0을 제거, false이면 소수점 이하 0을 제거하지 않는다.
 
 **예제 1** ::
 
@@ -242,6 +244,9 @@ JDBC 프로그래밍
 	
     --connection URL string when hold_cursor property specified for cursor holdability
     URL=jdbc:CUBRID:192.168.0.1:33000:demodb:public::?hold_cursor=true
+	
+    --connection URL string when oracleStyleNumberReturn property is specified for remove decimal zeros from the result value
+    URL=jdbc:CUBRID:192.168.0.1:33000:demodb:public::?oracleStyleNumberReturn=true
 
 **예제 2**
 

--- a/ko/api/jdbc.rst
+++ b/ko/api/jdbc.rst
@@ -205,7 +205,7 @@ JDBC 프로그래밍
     *  **preparedStmtCacheSize**: usePreparedStmtCache가 TRUE일 경우, 캐싱할 수 있는 갯수  (기본:25, 최소:1, 최대:2147483647)
     *  **preparedStmtCacheSqlLimit**: usePreparedStmtCache가 TRUE일 경우, 캐싱할 수 있는 SQL의 길이 (기본:256, 최소:1, 최대:2147483647)
     *  **hold_cursor**: 커서 유지 기능 설정(기본값: true). 이 값이 false 이면 CLOSE_CURSORS_AT_COMMIT이 설정되고, true 이면 HOLD_CURSORS_OVER_COMMIT이 설정된다. 자세한 내용은 :ref:`cursor-holding`\ 을 참고한다.
-    *  **oracleStyleNumberReturn**: oracleStyleNumberReturn가 true인 경우, double, float 타입의 결과 값에서 소수점 이하의 0을 제거, false이면 소수점 이하 0을 제거하지 않는다.
+    *  **oracleStyleNumberReturn**: oracleStyleNumberReturn가 true인 경우, double, float 타입의 결과 값에서 소수점 이하의 후행 0을 억제 (예: 0.12), false이면 후행 0가 그대로 표시된다 (예: 0.12000000)
 
 **예제 1** ::
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-190

Purpose
When double/float type values are expressed in JDBC and CCI, meaningless zeros exist below the decimal point. Also, JDBC and CCI express different methods.
Meaningless zeros were removed and the expression method was unified.

Implementation
N/A

Remarks
N/A