### PR TITLE
[CUBRIDMAN-194] Change the order of the list of files(database_schema_info) in the database_schema_info file

### DIFF
--- a/en/admin/migration.inc
+++ b/en/admin/migration.inc
@@ -218,13 +218,13 @@ The following is [options] used in **cubrid unloaddb**.
         demodb_schema_class
         demodb_schema_vclass
         demodb_schema_synonym
-        demodb_schema_vclass_query_spec
         demodb_schema_serial
         demodb_schema_procedure
         demodb_schema_server
         demodb_schema_pk
         demodb_schema_fk
         demodb_schema_grant
+        demodb_schema_vclass_query_spec
 
     Filename containing a list of splited schema files
     

--- a/ko/admin/migration.inc
+++ b/ko/admin/migration.inc
@@ -218,13 +218,13 @@ unloaddb
         demodb_schema_class
         demodb_schema_vclass
         demodb_schema_synonym
-        demodb_schema_vclass_query_spec
         demodb_schema_serial
         demodb_schema_procedure
         demodb_schema_server
         demodb_schema_pk
         demodb_schema_fk
         demodb_schema_grant
+        demodb_schema_vclass_query_spec
 
     분할된 스키마 파일들의 목록을 가지고 있는 파일명
     


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-194

Purpose
loaddb --schema-flie-list fails when load of dblink select query within create view.
because 'database_schema_vclass_query_spec' is load before 'database_schema_server' in 'database_schema_info'.
So I changed the file list order

Implementation
N/A

Remarks
N/A