### PR TITLE
[CUBRIDMAN-178] not allow to alter the column type to a type that does not support auto-increment.

### DIFF
--- a/en/sql/schema/table_stmt.rst
+++ b/en/sql/schema/table_stmt.rst
@@ -1425,6 +1425,29 @@ If you set the type, size, and attribute to apply to a new column with the **CHA
 When you change data types using the **CHANGE** clause or the **MODIFY** clause, the data can be modified. For example, if you shorten the length of a column, the character string may be truncated if the value of configuration parameter alter_table_change_type_strict is set to **no**. But if the parameter value is set to **yes**, the change or modify is not allowed and it returns an error.
 the configuration parameter allow_truncated_string also affect the similar as alter_table_change_type_strict.
 
+When changing the type of the column specified AUTO_INCREMENT, it cannot be changed to a column type that is not allowed to used with the AUTO_INCREMENT. For example, if you try to change the column type of "a" from INT to VARCHAR with the ALTER statement as shown below, an error occurs.
+
+.. code-block:: sql
+
+    CREATE a_tbl (a int AUTO_INCREMENT, b VARCHAR);
+    ALTER TABLE a_tbl MODIFY COLUMN a VARCHAR;
+
+::
+
+    ERROR: before '  varchar; '
+    The domain of the attribute 'a' having an auto increment constraint is invalid.
+
+When changing the type of a column specified  a default value, if the default value can't be coerced to the changed type, an error occurs as shown in the example below.
+
+.. code-block:: sql
+
+     CREATE TABLE t_def (a bigint default 123456789012, b varchar(20));
+     ALTER TABLE t_def a a int;
+
+::
+
+     ERROR: A domain conflict exists on attribute "a".
+
 .. warning::
 
     *   **ALTER TABLE** *[schema_name.]table_name* **CHANGE** *column_name* **DEFAULT** *default_value* syntax supported in CUBRID 2008 R3.1 or earlier version is no longer supported.

--- a/ko/sql/schema/table_stmt.rst
+++ b/ko/sql/schema/table_stmt.rst
@@ -1424,6 +1424,29 @@ CHANGE/MODIFY 절
 
 **CHANGE** 절이나 **MODIFY** 절로 칼럼에 데이터 타입을 변경할 때, 기존의 칼럼 값이 변경되면서 데이터가 변형될 수 있다. 예를 들어 문자열 칼럼의 길이를 줄이면 문자열이 잘릴 수 있으므로 주의해야 한다. 단, **alter_table_change_type_strict** 설정 값이 **yes** 인 경우 에러가 발생한다. 마찬가지로 **allow_truncated_string** 설정 값이 **no** 인 경우에도 에러가 발생한다.
 
+AUTO_INCREMENT 속성의 컬럼 타입을 변경할 경우, AUTO_INCREMENT 속성으로 사용할 수 없는 타입으로 변경할 수 없다. 예를 들면 아래와 같이 ALTER 구문으로 AUTO_INCREMENT 속성 컬럼인 a를 int에서 varchar 타입으로 변경시 에러가 발생한다.
+
+.. code-block:: sql
+
+    CREATE a_tbl (a int AUTO_INCREMENT, b VARCHAR);
+    ALTER TABLE a_tbl MODIFY COLUMN a VARCHAR;
+
+::
+
+    ERROR: before '  varchar; '
+    The domain of the attribute 'a' having an auto increment constraint is invalid.
+
+default값이 지정된 칼럼의 타입을 변경할 때, 지정된 default값이 변경된 타입으로 형변환이 불가능한 경우 아래의 예처럼 에러가 발생한다. 
+
+.. code-block:: sql
+
+    CREATE TABLE t_def (a bigint default 123456789012, b varchar(20));
+    ALTER TABLE t_def a a int;
+
+::
+
+    ERROR: A domain conflict exists on attribute "a".
+
 .. warning::
 
     *   CUBRID 2008 R3.1 이하 버전에서 사용되었던 **ALTER TABLE** *[schema_name.]table_name* **CHANGE** *column_name* **DEFAULT** *default_value* 구문은 더 이상 지원하지 않는다.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-178

This is a backport for 11.2 (#442)