### PR TITLE
[CUBRIDMAN-204] typo of the result of cubrid hb status

### DIFF
--- a/en/ha.rst
+++ b/en/ha.rst
@@ -1389,7 +1389,7 @@ This utility is used to output the information of CUBRID HA group and CUBRID HA 
      
      
      HA-Process Info (master 2143, state slave)
-       Applylogdb testdb@localhost:/home/cubrid/DB/testdb_nodeB (pid 2510, state registered)
+       Applylogdb testdb@localhost:/home/cubrid/DB/testdb_nodeA (pid 2510, state registered)
        Copylogdb testdb@nodeA:/home/cubrid/DB/testdb_nodeA (pid 2505, state registered)
        Server testdb (pid 2393, state registered_and_standby)
 

--- a/ko/ha.rst
+++ b/ko/ha.rst
@@ -1386,7 +1386,7 @@ CUBRID HA 그룹 정보와 CUBRID HA 구성 요소의 정보를 확인할 수 �
      
      
      HA-Process Info (master 2143, state slave)
-       Applylogdb testdb@localhost:/home/cubrid/DB/testdb_nodeB (pid 2510, state registered)
+       Applylogdb testdb@localhost:/home/cubrid/DB/testdb_nodeA (pid 2510, state registered)
        Copylogdb testdb@nodeA:/home/cubrid/DB/testdb_nodeA (pid 2505, state registered)
        Server testdb (pid 2393, state registered_and_standby)
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-204

```
Applylogdb testdb@localhost:/home/cubrid/DB/testdb_nodeB
```
to
```
Applylogdb testdb@localhost:/home/cubrid/DB/testdb_nodeA
```
in ko and en manual