### PR TITLE
[CUBRIDMAN-207] Add manual for SQL syntax to add users as members of the group

### DIFF
--- a/en/sql/authorization.rst
+++ b/en/sql/authorization.rst
@@ -26,7 +26,7 @@ CUBRID has two types of users by default: **DBA** and **PUBLIC**. At initial ins
 CREATE USER
 ===========
 
-You can create a user using the CREATE USER statement. At the initial installation, passwords for users are not configured. ::
+You can create a user using the CREATE USER statement. The default DBA, PUBLIC user is created without a password. ::
 
     CREATE USER user_name
     [PASSWORD password]
@@ -34,8 +34,8 @@ You can create a user using the CREATE USER statement. At the initial installati
     [MEMBERS user_name [{, user_name } ... ]] 
     [COMMENT 'comment_string'];
 
-*   *user_name*: specifies the user name to create, delete or change.
-*   *password*: specifies the user password to create or change.
+*   *user_name*: specifies the user name to create.
+*   *password*: specifies the user password to create.
 *   *comment_string*: specifies a comment for the user.
 
 .. note::
@@ -99,11 +99,11 @@ You can use the ALTER USER statement to change the password, members and comment
     ALTER USER user_name 
     [PASSWORD password] |
     [ADD MEMBERS user_name [{, user_name } ... ]] |
-    [DROP MEMBERS user_name [{, user_name } ... ]] |
+    [DROP MEMBERS user_name [{, user_name } ... ]]
     [COMMENT 'comment_string'];
 
-*   *user_name*: specifies the user name to create, delete or change.
-*   *password*: specifies the user password to create or change.
+*   *user_name*: specifies the user name to change.
+*   *password*: specifies the user password to change.
 *   *comment_string*: specifies a comment for the user.
 
 .. note::
@@ -153,22 +153,16 @@ The following example changes the comment for the created user.
     CREATE USER test_user1 COMMENT 'new user';
     ALTER USER test_user1 COMMENT 'old user';
 
-To see the changed comment, use the following syntax.
-
-.. code-block:: sql
-         
-    SELECT name, comment FROM db_user;
-
 .. _drop-user:
 
 DROP USER
 =========
 
-You can delete a user using the DROP USER statement. Users who are currently in use cannot be deleted. ::
+You can delete a user using the DROP USER statement. Users who own objects such as table, view, and trigger cannot delete them. ::
 
     DROP USER user_name;
 
-*   *user_name*: specifies the user name to create, delete or change.
+*   *user_name*: specifies the user name to delete.
 
 .. note::
 

--- a/en/sql/authorization.rst
+++ b/en/sql/authorization.rst
@@ -26,29 +26,27 @@ CUBRID has two types of users by default: **DBA** and **PUBLIC**. At initial ins
 CREATE USER
 ===========
 
-**DBA** and **DBA** members can create, drop and alter users by using SQL statements. At the initial installation, passwords for users are not configured. ::
+You can create a user using the CREATE USER statement. At the initial installation, passwords for users are not configured. ::
 
     CREATE USER user_name
     [PASSWORD password]
     [GROUPS user_name [{, user_name } ... ]]
     [MEMBERS user_name [{, user_name } ... ]] 
     [COMMENT 'comment_string'];
-    
-    DROP USER user_name;
-    
-    ALTER USER user_name PASSWORD password;
 
 *   *user_name*: specifies the user name to create, delete or change.
 *   *password*: specifies the user password to create or change.
 *   *comment_string*: specifies a comment for the user.
 
-The following example shows how to create a user (*Fred*), change a password, and delete the user.
+.. note::
+
+    Only **DBA** and **DBA** members can create users using the CREATE USER statement.
+
+The following example creates a user test_user1 and specifies a password.
 
 .. code-block:: sql
 
-    CREATE USER Fred;
-    ALTER USER Fred PASSWORD '1234';
-    DROP USER Fred;
+    CREATE USER test_user1 PASSWORD 'password';
 
 The following example shows how to create a user and add member to the user. By the following statement, *company* becomes a group that has *engineering*, *marketing* and *design* as its members. *marketing* becomes a group with members *smith* and *jones*, *design* becomes a group with a member *smith*, and *engineering* becomes a group with a member *brown*.
 
@@ -77,23 +75,112 @@ The following example shows how to create the same groups as above but use the *
 User's COMMENT
 --------------
 
-A comment for a user can be written as follows.
+The following example creates a user test_user1 and adds a password and a comment.
 
 .. code-block:: sql
 
-    CREATE USER designer GROUPS dbms, qa COMMENT 'user comment';
-
-A comment for a user can be changed as the following ALTER USER statement.
-
-.. code-block:: sql
-    
-    ALTER USER DESIGNER COMMENT 'new comment';
+    CREATE USER test_user1 PASSWORD 'password' COMMENT 'new user';
     
 You can see a comment for a user with this syntax.
 
 .. code-block:: sql
 
     SELECT name, comment FROM db_user;
+
+To change user comment, refer to the description of the ALTER USER statement.
+
+.. _alter-user:
+
+ALTER USER
+==========
+
+You can use the ALTER USER statement to change the password, members and comment of a created user. ::
+
+    ALTER USER user_name 
+    [PASSWORD password] |
+    [ADD MEMBERS user_name [{, user_name } ... ]] |
+    [DROP MEMBERS user_name [{, user_name } ... ]] |
+    [COMMENT 'comment_string'];
+
+*   *user_name*: specifies the user name to create, delete or change.
+*   *password*: specifies the user password to create or change.
+*   *comment_string*: specifies a comment for the user.
+
+.. note::
+
+    **DBA** and **DBA** members can use the ALTER USER statement to change the password, members and comment of **all users**.
+
+    **General users** can change **their own** password, member and comment using the ALTER USER statement.
+
+The following example creates a user test_user1 and changes the password.
+
+.. code-block:: sql
+
+    CREATE USER test_user1;
+    ALTER USER test_user1 PASSWORD '1234';
+
+The following example creates a user and adds members to the created user. This example does the same thing as the example in CREATE USER .. MEMBERS ..
+
+.. code-block:: sql
+
+    CREATE USER company;
+    CREATE USER engineering;
+    CREATE USER marketing;
+    CREATE USER design;
+    CREATE USER smith;
+    CREATE USER jones;
+    CREATE USER brown;
+
+    ALTER USER engineering ADD MEMBERS brown;
+    ALTER USER marketing ADD MEMBERS smith, jones;
+    ALTER USER design ADD MEMBERS smith;
+    ALTER USER company ADD MEMBERS engineering, marketing, design;
+
+The following example deletes the members of a created user group. The *marketing* member is deleted from the *company* group through the following sentence and the *marketing* group deletes *smith* and *jones* from the member.
+
+.. code-block:: sql
+
+    ALTER USER company DROP MEMBERS marketing;
+    ALTER USER marketing DROP MEMBERS smith, jones;
+
+User's COMMENT Change
+---------------------
+
+The following example changes the comment for the created user.
+
+.. code-block:: sql
+
+    CREATE USER test_user1 COMMENT 'new user';
+    ALTER USER test_user1 COMMENT 'old user';
+
+To see the changed comment, use the following syntax.
+
+.. code-block:: sql
+         
+    SELECT name, comment FROM db_user;
+
+.. _drop-user:
+
+DROP USER
+=========
+
+You can delete a user using the DROP USER statement. Users who are currently in use cannot be deleted. ::
+
+    DROP USER user_name;
+
+*   *user_name*: specifies the user name to create, delete or change.
+
+.. note::
+
+    Only **DBA** and **DBA** members can delete users using the DROP USER statement.
+
+The following example shows how to create a user (*Fred*), change a password, and delete the user.
+
+.. code-block:: sql
+
+    CREATE USER Fred;
+    ALTER USER Fred PASSWORD '1234';
+    DROP USER Fred; 
 
 .. _granting-authorization:
 

--- a/en/sql/authorization.rst
+++ b/en/sql/authorization.rst
@@ -36,7 +36,7 @@ You can create a user using the CREATE USER statement. The default DBA, PUBLIC u
 
 *   *user_name*: specifies the user name to create.
 *   *password*: specifies the user password to create.
-*   *comment_string*: specifies a comment for the user.
+*   *comment_string*: specifies the user comment to create.
 
 .. note::
 
@@ -104,7 +104,7 @@ You can use the ALTER USER statement to change the password, members and comment
 
 *   *user_name*: specifies the user name to change.
 *   *password*: specifies the user password to change.
-*   *comment_string*: specifies a comment for the user.
+*   *comment_string*: specifies the user comment to change.
 
 .. note::
 
@@ -158,7 +158,7 @@ The following example changes the comment for the created user.
 DROP USER
 =========
 
-You can delete a user using the DROP USER statement. Users who own objects such as table, view, and trigger cannot delete them. ::
+You can delete a user using the DROP USER statement. Users who own objects in table, view, trigger, stored function/procedure, serial, synonym, and server cannot delete them. ::
 
     DROP USER user_name;
 
@@ -168,13 +168,13 @@ You can delete a user using the DROP USER statement. Users who own objects such 
 
     Only **DBA** and **DBA** members can delete users using the DROP USER statement.
 
-The following example shows how to create a user (*Fred*), change a password, and delete the user.
+The following example shows how to create a user (*test_user1*), change a password, and delete the user.
 
 .. code-block:: sql
 
-    CREATE USER Fred;
-    ALTER USER Fred PASSWORD '1234';
-    DROP USER Fred; 
+    CREATE USER test_user1;
+    ALTER USER test_user1 PASSWORD '1234';
+    DROP USER test_user1; 
 
 .. _granting-authorization:
 

--- a/en/sql/authorization.rst
+++ b/en/sql/authorization.rst
@@ -158,7 +158,7 @@ The following example changes the comment for the created user.
 DROP USER
 =========
 
-You can delete a user using the DROP USER statement. Users who own objects in table, view, trigger, stored function/procedure, serial, synonym, and server cannot delete them. ::
+You can delete a user using the DROP USER statement. Users who own objects in table, view, trigger, stored function/procedure, serial, synonym, and server cannot be dropped. ::
 
     DROP USER user_name;
 

--- a/ko/conf.py
+++ b/ko/conf.py
@@ -163,8 +163,8 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_static_path = ['_static']
 
 def setup(app):
-  app.add_css_file('style.css')
-
+  #app.add_css_file('style.css')
+  app.add_stylesheet('style.css')
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 html_last_updated_fmt = '%b %d, %Y'

--- a/ko/sql/authorization.rst
+++ b/ko/sql/authorization.rst
@@ -136,7 +136,7 @@ ALTER USER 문을 사용하여 생성된 사용자의 패스워드, 멤버, 커�
     ALTER USER design ADD MEMBERS smith;
     ALTER USER company ADD MEMBERS engineering, marketing, design;
 
-다음은 생성된 사용자 그룹의 멤버를 삭제하는 예제이다. 다음 문장을 통해 company 그룹에서 marketing 멤버를 삭제하고, marketing 그룹은 smith, jones 를 멤버에서 삭제 한다.
+다음은 생성된 사용자 그룹의 멤버를 삭제하는 예제이다. 다음 문장을 통해 *company* 그룹에서 *marketing* 멤버를 삭제하고, *marketing* 그룹은 *smith*, *jones* 를 멤버에서 삭제 한다.
 
 .. code-block:: sql
 

--- a/ko/sql/authorization.rst
+++ b/ko/sql/authorization.rst
@@ -23,34 +23,32 @@ CUBRID는 기본적으로 **DBA** 와 **PUBLIC** 두 종류의 사용자를 제�
 
 .. _create-user:
 
-CREATE/ALTER/DROP USER
-======================
+CREATE USER
+===========
 
-**DBA** 와 **DBA** 의 멤버는 SQL 문을 사용하여 사용자를 생성, 변경, 삭제할 수 있다. ::
+CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 초기 설치 시에는 사용자의 비밀번호가 구성되지 않습니다. ::
 
     CREATE USER user_name
     [PASSWORD password]
     [GROUPS user_name [{, user_name } ... ]]
     [MEMBERS user_name [{, user_name } ... ]] 
     [COMMENT 'comment_string'];
-    
-    ALTER USER user_name PASSWORD password;
-    
-    DROP USER user_name;
 
 *   *user_name*: 생성, 삭제, 변경할 사용자 이름을 지정한다.
 *   *password*: 생성 혹은 변경할 사용자의 비밀번호를 지정한다.
 *   *comment_string*: 사용자에 대한 커멘트를 지정한다.
 
-다음은 사용자 *Fred* 를 생성하고 비밀번호를 변경한 후에 *Fred* 를 삭제하는 예제이다.
+.. note::
+
+    **DBA** 와 **DBA** 의 멤버만 CREATE USER 문을 사용하여 사용자를 생성할 수 있다.
+
+다음은 사용자 test_user1 을 생성하며 비밀번호를 지정하는 예제이다. 
 
 .. code-block:: sql
 
-    CREATE USER Fred;
-    ALTER USER Fred PASSWORD '1234';
-    DROP USER Fred;
+    CREATE USER test_user1 PASSWORD 'password';
 
-다음은 사용자를 생성하고 생성된 사용자에 멤버를 추가하는 예제이다. 다음 문장을 통해 *company* 는 *engineering*, *marketing*, *design* 을 멤버로 가지는 그룹이 된다. *marketing* 은 *smith*, *jones* 를, *design* 은 *smith* 를, *engineering* 은 *brown* 을 멤버로 가지는 그룹이 된다.
+다음은 사용자 생성과 동시에 멤버를 추가하는 예제이다. 다음 문장을 통해 *company* 는 *engineering*, *marketing*, *design* 을 멤버로 가지는 그룹이 된다. *marketing* 은 *smith*, *jones* 를, *design* 은 *smith* 를, *engineering* 은 *brown* 을 멤버로 가지는 그룹이 된다.
 
 .. code-block:: sql
 
@@ -72,28 +70,117 @@ CREATE/ALTER/DROP USER
     CREATE USER engineering MEMBERS brown;
     CREATE USER marketing MEMBERS smith, jones;
     CREATE USER design MEMBERS smith;
-    CREATE USER company MEMBERS engineering, marketing, design;
+    CREATE USER company MEMBERS engineering, marketing, design; 
 
 사용자의 커멘트
 ---------------
 
-사용자에 대한 커멘트는 다음과 같이 지정한다.
+다음은 사용자 test_user1 을 생성하며 비밀번호 와 커멘트를 추가하는 예제이다.
 
 .. code-block:: sql
 
-    CREATE USER designer GROUPS dbms, qa COMMENT 'user comment';
+    CREATE USER test_user1 PASSWORD 'password' COMMENT 'new user';
 
-사용자에 대한 커멘트는 ALTER USER 문을 사용하여 다음과 같이 변경이 가능하다.
-
-.. code-block:: sql
-    
-    ALTER USER DESIGNER COMMENT 'new comment';
-    
-다음 구문으로 사용자에 대한 커멘트를 확인할 수 있다.
+사용자의 커멘트를 확인하려면 다음의 구문을 실행한다.
 
 .. code-block:: sql
 
     SELECT name, comment FROM db_user;
+
+사용자의 커멘트 변경은 ALTER USER 문의 설명을 참고한다.
+
+.. _alter-user:
+
+ALTER USER
+==========
+
+ALTER USER 문을 사용하여 생성된 사용자의 패스워드, 멤버, 커멘트를 변경할 수 있다. ::
+
+    ALTER USER user_name 
+    [PASSWORD password] |
+    [ADD MEMBERS user_name [{, user_name } ... ]] |
+    [DROP MEMBERS user_name [{, user_name } ... ]] |
+    [COMMENT 'comment_string'];
+
+*   *user_name*: 생성, 삭제, 변경할 사용자 이름을 지정한다.
+*   *password*: 생성 혹은 변경할 사용자의 비밀번호를 지정한다.
+*   *comment_string*: 사용자에 대한 커멘트를 지정한다.
+
+.. note::
+
+    **DBA** 와 **DBA** 의 멤버는 ALTER USER 문을 사용하여 **모든 사용자** 의 패스워드, 멤버, 커멘트를 변경할 수 있다.
+
+    **일반 사용자** 는 ALTER USER 문을 사용하여 **본인** 의 패스워드, 멤버, 커멘트를 변경할 수 있다.
+
+다음은 사용자 test_user1 을 생성하고 비밀번호를 변경하는 예제이다. 
+
+.. code-block:: sql
+
+    CREATE USER test_user1;
+    ALTER USER test_user1 PASSWORD '1234';
+
+다음은 사용자를 생성하고 생성된 사용자에 멤버를 추가하는 예제이다. CREATE USER .. MEMBERS .. 의 예제와 동일하게 수행하는 예제이다.
+
+.. code-block:: sql
+
+    CREATE USER company;
+    CREATE USER engineering;
+    CREATE USER marketing;
+    CREATE USER design;
+    CREATE USER smith;
+    CREATE USER jones;
+    CREATE USER brown;
+
+    ALTER USER engineering ADD MEMBERS brown;
+    ALTER USER marketing ADD MEMBERS smith, jones;
+    ALTER USER design ADD MEMBERS smith;
+    ALTER USER company ADD MEMBERS engineering, marketing, design;
+
+다음은 생성된 사용자 그룹의 멤버를 삭제하는 예제이다. 다음 문장을 통해 company 그룹에서 marketing 멤버를 삭제하고, marketing 그룹은 smith, jones 를 멤버에서 삭제 한다.
+
+.. code-block:: sql
+
+    ALTER USER company DROP MEMBERS marketing;
+    ALTER USER marketing DROP MEMBERS smith, jones;
+
+사용자의 커멘트 변경
+--------------------
+
+다음은 생성된 사용자의 커멘트를 변경하는 예제이다.
+
+.. code-block:: sql
+
+    CREATE USER test_user1 COMMENT 'new user';
+    ALTER USER test_user1 COMMENT 'old user';
+
+사용자의 변경된 커멘트를 확인하려면 다음의 구문을 실행한다.
+
+.. code-block:: sql
+      
+    SELECT name, comment FROM db_user;
+
+.. _drop-user:
+
+DROP USER
+=========
+
+DROP USER 문을 사용하여 사용자를 삭제할 수 있다. 사용 중인 사용자는 삭제할 수 없다. ::
+
+    DROP USER user_name;
+
+*   *user_name*: 생성, 삭제, 변경할 사용자 이름을 지정한다.
+
+.. note::
+
+    **DBA** 와 **DBA** 의 멤버만 DROP USER 문을 사용하여 사용자를 삭제할 수 있다.
+
+다음은 사용자 Fred 를 생성하고 비밀번호를 변경한 후에 Fred 를 삭제하는 예제이다.
+
+.. code-block:: sql
+
+    CREATE USER Fred;
+    ALTER USER Fred PASSWORD '1234';
+    DROP USER Fred; 
 
 .. _granting-authorization:
 

--- a/ko/sql/authorization.rst
+++ b/ko/sql/authorization.rst
@@ -26,7 +26,7 @@ CUBRID는 기본적으로 **DBA** 와 **PUBLIC** 두 종류의 사용자를 제�
 CREATE USER
 ===========
 
-CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 기본으로 제공되는 **DBA**, **PUBLIC** 사용자는 비밀번호가 없이 생성됩니다. ::
+CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 기본으로 제공되는 **DBA**, **PUBLIC** 사용자는 비밀번호가 없이 생성된다. ::
 
     CREATE USER user_name
     [PASSWORD password]
@@ -36,13 +36,13 @@ CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 기본으로 
 
 *   *user_name*: 생성할 사용자 이름을 지정한다.
 *   *password*: 생성할 사용자의 비밀번호를 지정한다.
-*   *comment_string*: 사용자에 대한 커멘트를 지정한다.
+*   *comment_string*: 생성할 사용자에 대한 커멘트를 지정한다.
 
 .. note::
 
     **DBA** 와 **DBA** 의 멤버만 CREATE USER 문을 사용하여 사용자를 생성할 수 있다.
 
-다음은 test_user1 사용자를 생성하면서 비밀번호를 설정하는 예제이다.
+다음은 test_user1 사용자를 생성하고 비밀번호를 설정하는 예제이다.
 
 .. code-block:: sql
 
@@ -75,7 +75,7 @@ CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 기본으로 
 사용자의 커멘트
 ---------------
 
-다음은 test_user1 사용자를 생성하며 비밀번호 와 커멘트를 설정하는 예제이다.
+다음은 test_user1 사용자를 생성하고 비밀번호와 커멘트를 설정하는 예제이다.
 
 .. code-block:: sql
 
@@ -104,7 +104,7 @@ ALTER USER 문을 사용하여 사용자의 비밀번호, 멤버, 커멘트를 �
 
 *   *user_name*: 변경할 사용자 이름을 지정한다.
 *   *password*: 변경할 사용자의 비밀번호를 지정한다.
-*   *comment_string*: 사용자에 대한 커멘트를 지정한다.
+*   *comment_string*: 변경할 사용자에 대한 커멘트를 지정한다.
 
 .. note::
 
@@ -136,7 +136,7 @@ ALTER USER 문을 사용하여 사용자의 비밀번호, 멤버, 커멘트를 �
     ALTER USER design ADD MEMBERS smith;
     ALTER USER company ADD MEMBERS engineering, marketing, design;
 
-다음은 생성된 사용자 그룹의 멤버를 삭제하는 예제이다. 다음 문장을 통해 *company* 그룹에서 *marketing* 멤버를 삭제하고, *marketing* 그룹은 *smith*, *jones* 를 멤버에서 삭제 한다.
+다음은 생성된 사용자 그룹의 멤버를 삭제하는 예제이다. 다음 문장을 통해 *company* 그룹에서 *marketing* 멤버를 삭제하고, *marketing* 그룹은 *smith*, *jones* 를 멤버에서 삭제한다.
 
 .. code-block:: sql
 
@@ -158,7 +158,7 @@ ALTER USER 문을 사용하여 사용자의 비밀번호, 멤버, 커멘트를 �
 DROP USER
 =========
 
-DROP USER 문을 사용하여 사용자를 삭제할 수 있다. 테이블, 뷰, 트리거 등의 객체를 소유한 사용자는 삭제할 수 없다. ::
+DROP USER 문을 사용하여 사용자를 삭제할 수 있다. 테이블, 뷰, 트리거, 저장 함수/프로시저, 시리얼, 동의어, 서버의 객체를 소유한 사용자는 삭제할 수 없다. ::
 
     DROP USER user_name;
 
@@ -168,13 +168,13 @@ DROP USER 문을 사용하여 사용자를 삭제할 수 있다. 테이블, 뷰,
 
     **DBA** 와 **DBA** 의 멤버만 DROP USER 문을 사용하여 사용자를 삭제할 수 있다.
 
-다음은 사용자 Fred 를 생성하고 비밀번호를 변경한 후에 Fred 를 삭제하는 예제이다.
+다음은 test_user1 사용자를 생성하고 비밀번호 변경 후 test_user1 사용자를 삭제하는 예제이다.
 
 .. code-block:: sql
 
-    CREATE USER Fred;
-    ALTER USER Fred PASSWORD '1234';
-    DROP USER Fred; 
+    CREATE USER test_user1;
+    ALTER USER test_user1 PASSWORD '1234';
+    DROP USER test_user1; 
 
 .. _granting-authorization:
 

--- a/ko/sql/authorization.rst
+++ b/ko/sql/authorization.rst
@@ -26,7 +26,7 @@ CUBRID는 기본적으로 **DBA** 와 **PUBLIC** 두 종류의 사용자를 제�
 CREATE USER
 ===========
 
-CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 초기 설치 시에는 사용자의 비밀번호가 구성되지 않습니다. ::
+CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 기본으로 제공되는 **DBA**, **PUBLIC** 사용자는 비밀번호가 없이 생성됩니다. ::
 
     CREATE USER user_name
     [PASSWORD password]
@@ -34,15 +34,15 @@ CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 초기 설치
     [MEMBERS user_name [{, user_name } ... ]] 
     [COMMENT 'comment_string'];
 
-*   *user_name*: 생성, 삭제, 변경할 사용자 이름을 지정한다.
-*   *password*: 생성 혹은 변경할 사용자의 비밀번호를 지정한다.
+*   *user_name*: 생성할 사용자 이름을 지정한다.
+*   *password*: 생성할 사용자의 비밀번호를 지정한다.
 *   *comment_string*: 사용자에 대한 커멘트를 지정한다.
 
 .. note::
 
     **DBA** 와 **DBA** 의 멤버만 CREATE USER 문을 사용하여 사용자를 생성할 수 있다.
 
-다음은 사용자 test_user1 을 생성하며 비밀번호를 지정하는 예제이다. 
+다음은 test_user1 사용자를 생성하면서 비밀번호를 설정하는 예제이다.
 
 .. code-block:: sql
 
@@ -75,7 +75,7 @@ CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 초기 설치
 사용자의 커멘트
 ---------------
 
-다음은 사용자 test_user1 을 생성하며 비밀번호 와 커멘트를 추가하는 예제이다.
+다음은 test_user1 사용자를 생성하며 비밀번호 와 커멘트를 설정하는 예제이다.
 
 .. code-block:: sql
 
@@ -94,25 +94,25 @@ CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 초기 설치
 ALTER USER
 ==========
 
-ALTER USER 문을 사용하여 생성된 사용자의 패스워드, 멤버, 커멘트를 변경할 수 있다. ::
+ALTER USER 문을 사용하여 사용자의 비밀번호, 멤버, 커멘트를 변경할 수 있다. ::
 
     ALTER USER user_name 
     [PASSWORD password] |
     [ADD MEMBERS user_name [{, user_name } ... ]] |
-    [DROP MEMBERS user_name [{, user_name } ... ]] |
+    [DROP MEMBERS user_name [{, user_name } ... ]]
     [COMMENT 'comment_string'];
 
-*   *user_name*: 생성, 삭제, 변경할 사용자 이름을 지정한다.
-*   *password*: 생성 혹은 변경할 사용자의 비밀번호를 지정한다.
+*   *user_name*: 변경할 사용자 이름을 지정한다.
+*   *password*: 변경할 사용자의 비밀번호를 지정한다.
 *   *comment_string*: 사용자에 대한 커멘트를 지정한다.
 
 .. note::
 
-    **DBA** 와 **DBA** 의 멤버는 ALTER USER 문을 사용하여 **모든 사용자** 의 패스워드, 멤버, 커멘트를 변경할 수 있다.
+    **DBA** 와 **DBA** 의 멤버는 ALTER USER 문을 사용하여 **모든 사용자** 의 비밀번호, 멤버, 커멘트를 변경할 수 있다.
 
-    **일반 사용자** 는 ALTER USER 문을 사용하여 **본인** 의 패스워드, 멤버, 커멘트를 변경할 수 있다.
+    **일반 사용자** 는 ALTER USER 문을 사용하여 **본인** 의 비밀번호, 멤버, 커멘트를 변경할 수 있다.
 
-다음은 사용자 test_user1 을 생성하고 비밀번호를 변경하는 예제이다. 
+다음은 test_user1 사용자를 생성하고 비밀번호를 변경하는 예제이다. 
 
 .. code-block:: sql
 
@@ -153,22 +153,16 @@ ALTER USER 문을 사용하여 생성된 사용자의 패스워드, 멤버, 커�
     CREATE USER test_user1 COMMENT 'new user';
     ALTER USER test_user1 COMMENT 'old user';
 
-사용자의 변경된 커멘트를 확인하려면 다음의 구문을 실행한다.
-
-.. code-block:: sql
-      
-    SELECT name, comment FROM db_user;
-
 .. _drop-user:
 
 DROP USER
 =========
 
-DROP USER 문을 사용하여 사용자를 삭제할 수 있다. 사용 중인 사용자는 삭제할 수 없다. ::
+DROP USER 문을 사용하여 사용자를 삭제할 수 있다. 테이블, 뷰, 트리거 등의 객체를 소유한 사용자는 삭제할 수 없다. ::
 
     DROP USER user_name;
 
-*   *user_name*: 생성, 삭제, 변경할 사용자 이름을 지정한다.
+*   *user_name*: 삭제할 사용자 이름을 지정한다.
 
 .. note::
 

--- a/ko/sql/authorization.rst
+++ b/ko/sql/authorization.rst
@@ -48,7 +48,7 @@ CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 기본으로 
 
     CREATE USER test_user1 PASSWORD 'password';
 
-다음은 사용자 생성과 동시에 멤버를 추가하는 예제이다. 다음 문장을 통해 *company* 는 *engineering*, *marketing*, *design* 을 멤버로 가지는 그룹이 된다. *marketing* 은 *smith*, *jones* 를, *design* 은 *smith* 를, *engineering* 은 *brown* 을 멤버로 가지는 그룹이 된다.
+다음은 사용자 생성과 함께 멤버를 추가하는 예제이다. 다음 문장을 통해 *company* 는 *engineering*, *marketing*, *design* 을 멤버로 가지는 그룹이 된다. *marketing* 은 *smith*, *jones* 를, *design* 은 *smith* 를, *engineering* 은 *brown* 을 멤버로 가지는 그룹이 된다.
 
 .. code-block:: sql
 
@@ -94,7 +94,7 @@ CREATE USER 문을 사용하여 사용자를 생성할 수 있다. 기본으로 
 ALTER USER
 ==========
 
-ALTER USER 문을 사용하여 사용자의 비밀번호, 멤버, 커멘트를 변경할 수 있다. ::
+ALTER USER 문을 사용하여 사용자의 비밀번호, 멤버 및 커멘트를 변경할 수 있다. ::
 
     ALTER USER user_name 
     [PASSWORD password] |
@@ -108,9 +108,9 @@ ALTER USER 문을 사용하여 사용자의 비밀번호, 멤버, 커멘트를 �
 
 .. note::
 
-    **DBA** 와 **DBA** 의 멤버는 ALTER USER 문을 사용하여 **모든 사용자** 의 비밀번호, 멤버, 커멘트를 변경할 수 있다.
+    **DBA** 와 **DBA** 의 멤버는 ALTER USER 문을 사용하여 **모든 사용자** 의 비밀번호, 멤버 및 커멘트를 변경할 수 있다.
 
-    **일반 사용자** 는 ALTER USER 문을 사용하여 **본인** 의 비밀번호, 멤버, 커멘트를 변경할 수 있다.
+    **일반 사용자** 는 ALTER USER 문을 사용하여 **본인** 의 비밀번호, 멤버 및 커멘트를 변경할 수 있다.
 
 다음은 test_user1 사용자를 생성하고 비밀번호를 변경하는 예제이다. 
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-207

"ALTER USER ... ADD/DROP MEMBERS" is the SQL syntax to ADD/DROP MEMBERS of a group.

The "ALTER USER" section doesn't have information about ADD/DROP MEMBERS, it need to add a manual.
In addition, we will supplement the examples related to PASSWORD and COMMENT.