### PR TITLE
[CUBRIDMAN-210] Add manual for SQL syntax to change the owner of the serial

### DIFF
--- a/en/sql/authorization.rst
+++ b/en/sql/authorization.rst
@@ -195,9 +195,9 @@ The following example shows how to execute the **REVOKE** statement revoking all
 ALTER ... OWNER
 ===============
 
-Database Administrator (**DBA**) or a member of the **DBA** group can change the owner of table, view, trigger, and Java stored functions/procedures by using the following query. ::
+Database Administrator (**DBA**) or a member of the **DBA** group can change the owner of table, view, trigger, Java stored functions/procedures, and serial by using the following query. ::
 
-    ALTER (TABLE | CLASS | VIEW | VCLASS | TRIGGER | PROCEDURE | FUNCTION) [schema_name.]name OWNER TO user_id;
+    ALTER (TABLE | CLASS | VIEW | VCLASS | TRIGGER | PROCEDURE | FUNCTION | SERIAL) [schema_name.]name OWNER TO user_id;
 
 *   *schema_name*: Specifies the schema of the object. If omitted, the schema name of the current session is used.
 *   *name*: The name of schema object of which owner is to be changed
@@ -210,6 +210,7 @@ Database Administrator (**DBA**) or a member of the **DBA** group can change the
     ALTER TRIGGER test_trigger OWNER TO public;
     ALTER FUNCTION test_function OWNER TO public;
     ALTER PROCEDURE test_procedure OWNER TO public;
+    ALTER SERIAL test_serial OWNER TO public;
 
 .. _authorization-method:
 

--- a/en/sql/authorization.rst
+++ b/en/sql/authorization.rst
@@ -195,7 +195,7 @@ The following example shows how to execute the **REVOKE** statement revoking all
 ALTER ... OWNER
 ===============
 
-Database Administrator (**DBA**) or a member of the **DBA** group can change the owner of table, view, trigger, Java stored functions/procedures, and serial by using the following query. ::
+Database Administrator (**DBA**) or a member of the **DBA** group can change the owner of table, view, trigger, stored functions/procedures, and serial by using the following query. ::
 
     ALTER (TABLE | CLASS | VIEW | VCLASS | TRIGGER | PROCEDURE | FUNCTION | SERIAL) [schema_name.]name OWNER TO user_id;
 

--- a/ko/sql/authorization.rst
+++ b/ko/sql/authorization.rst
@@ -195,7 +195,7 @@ REVOKE
 ALTER ... OWNER
 ===============
 
-데이터베이스 관리자(**DBA**) 또는 **DBA** 그룹의 멤버는 다음 질의를 통해 테이블, 뷰, 트리거, 저장 함수/프로시저, 시리얼의 소유자를 변경할 수 있다. ::
+데이터베이스 관리자(**DBA**) 또는 **DBA** 그룹의 멤버는 다음 질의를 통해 테이블, 뷰, 트리거, 저장 함수/프로시저 및 시리얼의 소유자를 변경할 수 있다. ::
 
     ALTER (TABLE | CLASS | VIEW | VCLASS | TRIGGER | PROCEDURE | FUNCTION | SERIAL) [schema_name.]name OWNER TO user_id;
 

--- a/ko/sql/authorization.rst
+++ b/ko/sql/authorization.rst
@@ -195,9 +195,9 @@ REVOKE
 ALTER ... OWNER
 ===============
 
-데이터베이스 관리자(**DBA**) 또는 **DBA** 그룹의 멤버는 다음의 질의를 통해 테이블, 뷰, 트리거, Java 저장 함수/프로시저의 소유자를 변경할 수 있다. ::
+데이터베이스 관리자(**DBA**) 또는 **DBA** 그룹의 멤버는 다음의 질의를 통해 테이블, 뷰, 트리거, Java 저장 함수/프로시저, 시리얼의 소유자를 변경할 수 있다. ::
 
-    ALTER (TABLE | CLASS | VIEW | VCLASS | TRIGGER | PROCEDURE | FUNCTION) [schema_name.]name OWNER TO user_id;
+    ALTER (TABLE | CLASS | VIEW | VCLASS | TRIGGER | PROCEDURE | FUNCTION | SERIAL) [schema_name.]name OWNER TO user_id;
 
 *   *schema_name*: 객체의 스키마 이름을 지정한다. 생략하면 현재 세션의 스키마 이름을 사용한다.
 *   *name*: 소유자를 변경할 스키마 객체의 이름
@@ -210,6 +210,7 @@ ALTER ... OWNER
     ALTER TRIGGER test_trigger OWNER TO public;
     ALTER FUNCTION test_function OWNER TO public;
     ALTER PROCEDURE test_procedure OWNER TO public;
+    ALTER SERIAL test_serial OWNER TO public;    
 
 .. _authorization-method:
 

--- a/ko/sql/authorization.rst
+++ b/ko/sql/authorization.rst
@@ -195,7 +195,7 @@ REVOKE
 ALTER ... OWNER
 ===============
 
-데이터베이스 관리자(**DBA**) 또는 **DBA** 그룹의 멤버는 다음의 질의를 통해 테이블, 뷰, 트리거, Java 저장 함수/프로시저, 시리얼의 소유자를 변경할 수 있다. ::
+데이터베이스 관리자(**DBA**) 또는 **DBA** 그룹의 멤버는 다음 질의를 통해 테이블, 뷰, 트리거, 저장 함수/프로시저, 시리얼의 소유자를 변경할 수 있다. ::
 
     ALTER (TABLE | CLASS | VIEW | VCLASS | TRIGGER | PROCEDURE | FUNCTION | SERIAL) [schema_name.]name OWNER TO user_id;
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-210

"ALTER SERIAL .. OWNER TO .." is the SQL syntax to change the owner of a SERIAL.

We will add SERIAL to the ALTER ... OWNER session of User Management.