### PR TITLE
docs(intro): fix invalid process_structure.png path

### DIFF
--- a/ko/intro.rst
+++ b/ko/intro.rst
@@ -33,7 +33,7 @@ CUBRID는 객체 관계형 데이터베이스 관리 시스템으로서, 데이�
 
 .. FIXME: For more information about CUBRID Manager, see http://www.cubrid.org/wiki_tools/entry/cubrid-manager.
 
-.. image:: /images/process_structure.png
+.. image:: images/process_structure.png
 
 .. _database-volume-structure:
 


### PR DESCRIPTION
이미지 url 앞에 /가 포함되어 깃헙에서 rst 문서에 이미지가 표시되지 않아 이를 수정합니다.

다른 이미지들의 링크를 참고하여 오타를 제거했습니다. (/images -> images)

---

The image URL was incorrect and not displaying in the rst file on GitHub, so I have corrected it.

By referencing the links of other images, I removed the typo. (/images -> images)