### PR TITLE
docs(intro): fix invalid image urls in en manual

### DIFF
--- a/en/intro.rst
+++ b/en/intro.rst
@@ -33,7 +33,7 @@ CUBRID is an object-relational database management system (DBMS) consisting of t
 
 .. FIXME: For more information about CUBRID Manager, see http://www.cubrid.org/wiki_tools/entry/cubrid-manager.
 
-.. image:: /images/process_structure.png
+.. image:: images/process_structure.png
 
 .. _database-volume-structure:
 
@@ -42,7 +42,7 @@ Database Volume Structure
 
 The following diagram illustrates the CUBRID database volume structure. As you can see, the database is divided into three volumes: permanent, temporary and backup. This chapter will examine each volume and its characteristics.
 
-.. image:: /images/database_volume_structure.png
+.. image:: images/database_volume_structure.png
 
 For commands to create, add or delete the database volume, see :ref:`creating-database`, :ref:`adding-database-volume` and :ref:`deleting-database`.
 


### PR DESCRIPTION
한글 매뉴얼 #504와 마찬가지로, 영어 매뉴얼 images url 앞에 / 오타가 있어 깃헙에서 rst 파일이 제대로 렌더링이 안 되는 현상을 수정합니다. 

---

Like #504, The image URLs were incorrect and not displaying in the rst file on GitHub, so I have corrected it.

By referencing the links of other images, I removed the typo. (/images -> images)