### PR TITLE
[CUBRIDMAN-212] When using --split-schema-files in unloaddb, a function to separate unique information from the dbname_schema_class file has been added.

### DIFF
--- a/en/admin/migration.inc
+++ b/en/admin/migration.inc
@@ -223,6 +223,7 @@ The following is [options] used in **cubrid unloaddb**.
         demodb_schema_server
         demodb_schema_pk
         demodb_schema_fk
+        demodb_schema_uk
         demodb_schema_grant
         demodb_schema_vclass_query_spec
 

--- a/ko/admin/migration.inc
+++ b/ko/admin/migration.inc
@@ -223,6 +223,7 @@ unloaddb
         demodb_schema_server
         demodb_schema_pk
         demodb_schema_fk
+        demodb_schema_uk
         demodb_schema_grant
         demodb_schema_vclass_query_spec
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-212

Purpose
When --split-schema-files is used in unloaddb, the dbname_schema_uk file is extracted, and dbname_schema_uk is added to the dbname_schema_info file.

Implementation
demodb_schema_user
demodb_schema_class
demodb_schema_vclass
demodb_schema_synonym
demodb_schema_serial
demodb_schema_procedure
demodb_schema_server
demodb_schema_pk
demodb_schema_fk
**demodb_schema_uk**
demodb_schema_grant
demodb_schema_vclass_query_spec

Remarks
N/A