### PR TITLE
[CUBRIDMAN-227] 11.3, fix broken link for perl DBI

### DIFF
--- a/en/api/perl.rst
+++ b/en/api/perl.rst
@@ -24,7 +24,7 @@ Installing and Configuring Perl
 
 *   Perl: It is recommended to use an appropriate version of Perl based on your system environment. For example, all Linux and FreeBSD distributions come with Perl. For Windows, ActivePerl is recommended. For details, see https://www.activestate.com/products/perl/ .
 
-*   CUBRID: To build CUBRID Perl driver, you need to get the CCI driver. You can get it from installing CUBRID. You can download the CUBRID Perl driver's source code from https://www.cubrid.org/downloads .
+*   CUBRID: To build the CUBRID Perl driver, the CCI driver is needed. You can obtain it by installing the CUBRID Engine, which can be downloaded from https://www.cubrid.org/downloads. After downloading and installing a proper version of the CUBRID Engine, you can find the required CCI driver in the installed CUBRID Engine directory, $CUBRID/cci.
 
 *   DBI: https://metacpan.org/dist/DBI/ .
 

--- a/en/api/perl.rst
+++ b/en/api/perl.rst
@@ -26,7 +26,7 @@ Installing and Configuring Perl
 
 *   CUBRID: To build CUBRID Perl driver, you need to get the CCI driver. You can get it from installing CUBRID. You can download the CUBRID Perl driver's source code from https://www.cubrid.org/downloads .
 
-*   DBI: http://code.activestate.com/ppm/DBI/ .
+*   DBI: https://metacpan.org/dist/DBI/ .
 
 *   C compiler: In most cases, there are binary distributions of **DBD::cubrid** ( https://www.cubrid.org/downloads#perl ) available. However, if you want to build the driver from source code, a C compiler is required. Make sure to use the same C compiler that was used for compiling Perl and CUBRID. Otherwise, you will encounter problems because of differences in the underlying C runtime libraries.
 

--- a/en/api/perl.rst
+++ b/en/api/perl.rst
@@ -26,7 +26,7 @@ Installing and Configuring Perl
 
 *   CUBRID: To build the CUBRID Perl driver, the CCI driver is needed. You can obtain it by installing the CUBRID Engine, which can be downloaded from https://www.cubrid.org/downloads. After downloading and installing a proper version of the CUBRID Engine, you can find the required CCI driver in the installed CUBRID Engine directory, $CUBRID/cci.
 
-*   DBI: https://metacpan.org/dist/DBI/ .
+*   DBI: https://metacpan.org/dist/DBI/
 
 *   C compiler: In most cases, there are binary distributions of **DBD::cubrid** ( https://www.cubrid.org/downloads#perl ) available. However, if you want to build the driver from source code, a C compiler is required. Make sure to use the same C compiler that was used for compiling Perl and CUBRID. Otherwise, you will encounter problems because of differences in the underlying C runtime libraries.
 

--- a/en/api/perl.rst
+++ b/en/api/perl.rst
@@ -24,7 +24,7 @@ Installing and Configuring Perl
 
 *   Perl: It is recommended to use an appropriate version of Perl based on your system environment. For example, all Linux and FreeBSD distributions come with Perl. For Windows, ActivePerl is recommended. For details, see https://www.activestate.com/products/perl/ .
 
-*   CUBRID: To build the CUBRID Perl driver, the CCI driver is needed. You can obtain it by installing the CUBRID Engine, which can be downloaded from https://www.cubrid.org/downloads. After downloading and installing a proper version of the CUBRID Engine, you can find the required CCI driver in the installed CUBRID Engine directory, $CUBRID/cci.
+*   CUBRID: To build the CUBRID Perl driver, the CCI driver is needed. You can obtain it by installing the CCI driver, which can be downloaded from https://www.cubrid.org/downloads. 
 
 *   DBI: https://metacpan.org/dist/DBI/
 

--- a/ko/api/perl.rst
+++ b/ko/api/perl.rst
@@ -26,7 +26,7 @@ Perl 설치 및 설정
 
 *   CUBRID: Perl 드라이버를 빌드하기 위해 CCI 드라이버가 필요하며, 이를 위해 CUBRID를 설치해야 한다. CUBRID는 https://www.cubrid.org/downloads\ 에서 다운로드한다.
 
-*   DBI: http://code.activestate.com/ppm/DBI/
+*   DBI: https://metacpan.org/dist/DBI/
 
 *   C 컴파일러: 대부분의 경우에는 **DBD::cubrid** 바이너리(https://www.cubrid.org/downloads#perl)를 사용할 수 있으나, 만약 소스코드에서 드라이버를 빌드하려면 C 컴파일러가 필요하다. C 컴파일러를 사용하려면 Perl과 CUBRID를 컴파일한 컴파일러와 같은 컴파일러를 사용해야 한다. 그렇지 않으면 C 런타임 라이브러리 차이 때문에 문제가 발생할 수 있다.
 

--- a/ko/api/perl.rst
+++ b/ko/api/perl.rst
@@ -24,7 +24,7 @@ Perl 설치 및 설정
 
 *   Perl: 시스템에 적합한 버전의 Perl을 사용하는 것을 권장한다. 모든 Linux와 FreeBSD에는 Perl이 포함되어 있으며, Windows에서는 ActivePerl을 권장한다. Active Perl에 대한 자세한 내용은 https://www.activestate.com/products/perl\ 을 참고한다.
 
-*   CUBRID: Perl 드라이버를 빌드하기 위해 CCI 드라이버가 필요하며, 이를 위해 CUBRID Engin을 설치해야 한다. https://www.cubrid.org/downloads\ 에서 필요한 버전의 CUBRID Engine을 다운로드 하여 설치하면 된다. CUBRID Engine의 설치후 CCI 드라이버는 CUBRID 기본 경로 $CUBRID/cci에서 확인할 수 있다.
+*   CUBRID: Perl 드라이버를 빌드하기 위해 CCI 드라이버가 필요하며, https://www.cubrid.org/downloads\ 에서 필요한 버전의 CCI 드라이버를 다운로드 하여 설치하면 된다. 
 
 *   DBI: https://metacpan.org/dist/DBI/
 

--- a/ko/api/perl.rst
+++ b/ko/api/perl.rst
@@ -24,7 +24,7 @@ Perl 설치 및 설정
 
 *   Perl: 시스템에 적합한 버전의 Perl을 사용하는 것을 권장한다. 모든 Linux와 FreeBSD에는 Perl이 포함되어 있으며, Windows에서는 ActivePerl을 권장한다. Active Perl에 대한 자세한 내용은 https://www.activestate.com/products/perl\ 을 참고한다.
 
-*   CUBRID: Perl 드라이버를 빌드하기 위해 CCI 드라이버가 필요하며, 이를 위해 CUBRID를 설치해야 한다. CUBRID는 https://www.cubrid.org/downloads\ 에서 다운로드한다.
+*   CUBRID: Perl 드라이버를 빌드하기 위해 CCI 드라이버가 필요하며, 이를 위해 CUBRID Engin을 설치해야 한다. https://www.cubrid.org/downloads\ 에서 필요한 버전의 CUBRID Engine을 다운로드 하여 설치하면 된다. CUBRID Engine의 설치후 CCI 드라이버는 CUBRID 기본 경로 $CUBRID/cci에서 확인할 수 있다.
 
 *   DBI: https://metacpan.org/dist/DBI/
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-227

Description
* backport of #524 to release/11.3