### PR TITLE
[CUBRIDMAN-235] CUBRID_TMP description

### DIFF
--- a/en/env.rst
+++ b/en/env.rst
@@ -36,7 +36,7 @@ CUBRID Environment Variables
 
 .. note::
 
-    * If the **CUBRID_TMP** environment variable is set, value of **java.io.tmpdir** among **java_stored_procedure_jvm_options** is ignored. Which is an option used by the cub_javasp process (built-in Java VM) to store temporary files, instead it will use the directory specified by CUBRID_TMP.
+    * **java.io.tmpdir** among **java_stored_procedure_jvm_options** is an option that specifies the directory where temporary files of the cub_javasp process (built-in Java VM) are created. If the **CUBRID_TMP** environment variable is set, value of **java.io.tmpdir** is ignored, instead it will use the directory specified by CUBRID_TMP. 
 
     * To set this environment variable in Windows, you must add the CUBRID_TMP key to the registry (refer **%CUBRID%**\\share\\windows_scripts\\cubrid_env.bat).
 

--- a/en/env.rst
+++ b/en/env.rst
@@ -21,18 +21,24 @@ CUBRID Environment Variables
     *   A user of CUBRID Manager should specify **CUBRID_MSG_LANG**, an environment variable of DB server node into **en_US** to print out messages normally after running database related features. However, database related features are run normally and just the output messages are broken when **CUBRID_MSG_LANG** is not **en_US**.
     *   To apply the changed **CUBRID_MSG_LANG**, CUBRID system of DB server node should be restarted(cubrid service stop, cubrid service start).
 
-*   **CUBRID_TMP**: The environment variable that specifies the location where CUBRID for Linux stores the UNIX domain socket file. If it is not specified, the Unix domain socket file is stored in the following directory according to the process. (not used in CUBRID for Windows)
+*   **CUBRID_TMP**: The environment variable that specifies the location where CUBRID stores temporary files. There are two types of temporary files: regular files and UNIX domain sockets. If specified, temporary files are created in the directory specified in the environment variable CUBRID_TMP.
 
-    *   the cub_master process: under **/tmp** directory
-    *   the cub_broekr process: under **$CUBRID/var/CUBRID_SOCK** directory
-    *   the cub_javasp process: under **$CUBRID/var/CUBRID_SOCK** directory
+    *   **Regular files**: Temporary files are created by utilities such as **plandump** in addition to the database server and csql. If this environment variable is not set, the following directory is used.
+
+        * Linux: /tmp
+        * Windows: C:\\Windows\\TEMP
+
+    *   **UNIX Domain Socket files**: if this environment variable is not set, UNIX Domain sockets will be created in the directory for each process as follow (Applicable to **Linux** only and does not apply to **Windows**):
+    
+        *   cub_master: **/tmp**
+        *   cub_broker process: **$CUBRID/var/CUBRID_SOCK**
+        *   cub_javasp process: **$CUBRID/var/CUBRID_SOCK**
 
 .. note::
 
-    The **CUBRID_TMP** environment variable affects the **java.io.tmpdir**, specifying the path for temporary files created by the Java VM running in the cub_javasp process. 
-    If the **CUBRID_TMP** environment variable is set, the path for temporary files is designated to the path of the CUBRID_TMP environment variable, to properly store Unix domain socket files.
-    Therefore, even if a user specifies the value of **java.io.tmpdir** through the **java_stored_procedure_jvm_options** parameter, it will be ignored. 
-    This behavior applies only to CUBRID for Linux, which supports Unix domain sockets, and not to CUBRID for Windows.
+    * If the **CUBRID_TMP** environment variable is set, value of **java.io.tmpdir** among **java_stored_procedure_jvm_options** is ignored. Which is an option used by the cub_javasp process (built-in Java VM) to store temporary files, instead it will use the directory specified by CUBRID_TMP.
+
+    * To set this environment variable in Windows, you must add the CUBRID_TMP key to the registry (refer **%CUBRID%**\\share\\windows_scripts\\cubrid_env.bat).
 
 **CUBRID_TMP** value has some constraints, which are as follows:
 

--- a/en/env.rst
+++ b/en/env.rst
@@ -28,7 +28,7 @@ CUBRID Environment Variables
         * Linux: /tmp
         * Windows: C:\\Windows\\TEMP
 
-    *   **UNIX Domain Socket files**: if this environment variable is not set, UNIX Domain sockets will be created in the directory for each process as follow (Applicable to **Linux** only and does not apply to **Windows**):
+    *   **UNIX Domain Socket files**: If this environment variable is not set, UNIX Domain sockets will be created in the following directories for each process (Applicable to **Linux** only and does not apply to **Windows**):
     
         *   cub_master: **/tmp**
         *   cub_broker process: **$CUBRID/var/CUBRID_SOCK**

--- a/en/env.rst
+++ b/en/env.rst
@@ -36,7 +36,7 @@ CUBRID Environment Variables
 
 .. note::
 
-    * **java.io.tmpdir** among **java_stored_procedure_jvm_options** is an option that specifies the directory where temporary files of the cub_javasp process (built-in Java VM) are created. If the **CUBRID_TMP** environment variable is set, value of **java.io.tmpdir** is ignored, instead it will use the directory specified by CUBRID_TMP. 
+    * **java.io.tmpdir** among **java_stored_procedure_jvm_options** is an option that specifies the directory where temporary files of the cub_javasp process (built-in Java VM) are created. If the **CUBRID_TMP** environment variable is set, the value of **java.io.tmpdir** is ignored, and the directory specified by CUBRID_TMP will be used instead.
 
     * To set this environment variable in Windows, you must add the CUBRID_TMP key to the registry (refer **%CUBRID%**\\share\\windows_scripts\\cubrid_env.bat).
 

--- a/ko/env.rst
+++ b/ko/env.rst
@@ -21,18 +21,23 @@ CUBRID 환경 변수
     *  CUBRID Manager 사용자는 DB 서버 노드의 **CUBRID_MSG_LANG** 환경 변수를 **en_US** 로 설정해야만 데이터베이스 관련 작업 이후 출력되는 메시지를 정상적으로 확인할 수 있다.  **CUBRID_MSG_LANG** 환경 변수가 **en_US** 가 아닌 경우 메시지는 비정상적으로 출력되지만 데이터베이스의 작업은 정상적으로 실행된다.
     *  변경한 **CUBRID_MSG_LANG** 을  적용하려면 DB 서버 노드의 CUBRID 시스템이 반드시 재시작(cubrid service stop; cubrid service start)되어야 한다.
 
-*   **CUBRID_TMP**: Linux용 CUBRID에서 유닉스 도메인 소켓 파일을 저장하는 위치를 지정하는 환경 변수로, 지정하지 않으면 프로세스에 따라 다음의 디렉터리에 유닉스 도메인 소켓 파일을 저장한다 (Windows용 CUBRID에서는 사용되지 않는다).
+*   **CUBRID_TMP**: CUBRID DBMS를 구동에 필요한 임시 파일을 저장하기 위한 디렉터리를 설정하는 환경 변수이다. 임시 파일은 텍스트형과 프로세스간 통신을 위한 UNIX 도메인 소켓의 두 종류가 있다. 이 환경 변수가 설정된 경우 임시 파일은 환경 변수에 지정된 디렉터리에 생성된다.
+
+    *   **텍스트형** 임시 파일은 데이터베이스 서버, csql 이외에도 **plandump** 등과 같은 유틸리티에서 생성하며 이 환경 변수가 설정되지 않으면 다음의 디렉터리를 사용한다.
+
+        * Linux: /tmp
+        * Windows: C:\\Windows\\TEMP
+
+    *   **UNIX 도메인 소켓 파일** 은 이 환경 변수가 설정되지 않은 경우 프로세스 별로 아래의 경로에 생성된다 (이 소켓 파일은 **Linux에만 해당** 되며 Windows에는 적용되지 않는다).
     
-    *   cub_master 프로세스: **/tmp** 디렉터리
-    *   cub_broker 프로세스: **$CUBRID/var/CUBRID_SOCK** 디렉터리
-    *   cub_javasp 프로세스: **$CUBRID/var/CUBRID_SOCK** 디렉터리
+        *   cub_master 프로세스: **/tmp** 디렉터리
+        *   cub_broker 프로세스: **$CUBRID/var/CUBRID_SOCK** 디렉터리
+        *   cub_javasp 프로세스: **$CUBRID/var/CUBRID_SOCK** 디렉터리
 
 .. note::
 
-    **CUBRID_TMP** 환경 변수는 cub_javasp 프로세스 구동하는 Java VM에서 생성하는 임시 파일의 저장 경로를 지정하기 위한 **java.io.tmpdir** 환경 변수에 영향을 준다.
-    만약 **CUBRID_TMP** 환경 변수가 설정된 경우, 임시 파일의 저장 경로는 유닉스 도메인 소켓 파일을 올바르게 저장하기 위해 **CUBRID_TMP** 환경 변수의 경로로 지정된다.
-    따라서 사용자가 **java_stored_procedure_jvm_options** 파라미터를 통해 **java.io.tmpdir** 의 값을 지정하더라도 무시된다.
-    이 동작은 오직 유닉스 도메인 소켓을 지원하는 Linux용 CUBRID에서만 해당하며, Windows용 CUBRID에서는 해당하지 않는다.
+    * **CUBRID_TMP** 환경 변수가 설정된 경우 cub_javasp 프로세스 구동하는 Java VM에서 생성하는 임시 파일의 저장 경로를 지정하기 위해 **java_stored_procedure_jvm_options** 를 통해 지정된 **java.io.tmpdir** 의 값은 무시된다.
+    * Windows에서 이 환경 변수를 설정하기 위해서는 registry에 CUBRID_TMP key를 추가해야한다 (**%CUBRID%**\\share\\windows_scripts\\cubrid_env.bat 참조).
 
 **CUBRID_TMP** 의 값에는 다음과 같은 제약 사항이 있다.
 

--- a/ko/env.rst
+++ b/ko/env.rst
@@ -36,7 +36,7 @@ CUBRID 환경 변수
 
 .. note::
 
-    * **CUBRID_TMP** 환경 변수가 설정된 경우 cub_javasp 프로세스 구동하는 Java VM에서 생성하는 임시 파일의 저장 경로를 지정하기 위해 **java_stored_procedure_jvm_options** 를 통해 지정된 **java.io.tmpdir** 의 값은 무시된다.
+    * **CUBRID_TMP** 환경 변수가 설정된 경우, cub_javasp 프로세스(Java VM 내장) 구동시 사용하는  **java_stored_procedure_jvm_options** 중  임시 파일 저장 경로를 지정하는 **java.io.tmpdir** 의 설정값은 무시된다.
     * Windows에서 이 환경 변수를 설정하기 위해서는 registry에 CUBRID_TMP key를 추가해야한다 (**%CUBRID%**\\share\\windows_scripts\\cubrid_env.bat 참조).
 
 **CUBRID_TMP** 의 값에는 다음과 같은 제약 사항이 있다.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-235

**Description**
* 현재의 매뉴얼은 **CUBRID_TMP** 환경 변수를 Linux에서의 UNIX Domain Socket을 생성하는 것에 초점을 맞추어 기술되어 있다.
* 여기에 더해서, 이 환경 변수가 설정된 경우 텍스트형 임시 파일의 생성 위치도 변경되는데 이 부분을 수정할 필요가 있다.