### PR TITLE
[CUBRIDMAN-245] Change fsqlf download link

### DIFF
--- a/en/csql.rst
+++ b/en/csql.rst
@@ -1432,7 +1432,7 @@ This command specifies the formatter to be used with **;EDIT** session command. 
 
         The use of Free SQL Formatter is recommended.
 
-        Download URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.tar.gz
+        Download URL: https://github.com/CUBRID/fsqlf/releases
 
 **Specifying the editor (;EDITOR_Cmd)**
 

--- a/ko/csql.rst
+++ b/ko/csql.rst
@@ -1432,7 +1432,7 @@ OPT LEVEL의 상세한 내용은 :ref:`viewing-query-plan`\ 를 참고한다.
     
         Free SQL Formatter 사용을 권고합니다.
 
-        다운로드 URL: https://github.com/CUBRID/fsqlf/releases/download/v.1.1.0-csql/fsqlf-1.1.0.csql.tar.gz
+        다운로드 URL: https://github.com/CUBRID/fsqlf/releases
 
 **편집기 설정(;EDITOR_Cmd)**
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-245

**Purpose**

- fsqlf 다운로드 URL을 fsqlf 리포지토리의 releases 페이지로 변경합니다.

**Remarks**
https://github.com/CUBRID/fsqlf/releases