### PR TITLE
[CUBRIDMAN-247] add warning for absolute pathname in Windows

### DIFF
--- a/en/admin/control.rst
+++ b/en/admin/control.rst
@@ -1481,6 +1481,9 @@ The format of **ACCESS_CONTROL_FILE** is as follows:
 [%<*broker_name*>] and <*db_name*>:<*db_user*>:<*ip_list_file*> can be specified separately for each broker. A separated line can be specified for the same <*db_name*> and the same <*db_user*>.
 List of IPs can be written up to the maximum of 256 lines per <*db_name*>:<*db_user*> in a broker.
  
+.. note::
+    When using an absolute path name in Windows, the DRIVE name must be specified (for example, C:\\CUBRID\\CONF\\CUBRID_ACL.CONF).
+
 The format of the ip_list_file is as follows:  
 
 ::

--- a/ko/admin/control.rst
+++ b/ko/admin/control.rst
@@ -1471,6 +1471,11 @@ SHARD-Q는 Shard Waiting Queue를 줄인 말이다. SHARD proxy 프로세스가 
 *   <db_user>: 데이터베이스 사용자 ID. \*로 지정하면 모든 데이터베이스 사용자 ID를 허용한다.
 *   <ip_list_file>: 접속 가능한 IP 목록을 저장한 파일의 이름. ip_list_file1, ip_list_file2, ...와 같이 파일 여러 개를 쉼표(,)로 구분하여 지정할 수 있다.
 
+.. note::
+
+    Windows에서 절대 경로명 사용시 드라이브명을 반드시 명시해야 한다 
+    (예, C:\\CUBRID\\CONF\\CUBRID_ACL.CONF).
+
 브로커별로 [%<*broker_name*>]과 <*db_name*>:*<db_user*>:<*ip_list_file*>을 추가 지정할 수 있으며, 같은 <*db_name*>, 같은 <*db_user*>에 대해 별도의 라인으로 추가 지정할 수 있다.
 IP 목록은 하나의 브로커 내에서 <*db_name*>:<*db_user*> 별로 최대 256 라인까지 작성될 수 있다.
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-247

**Description**
* BROKER ACL record
  * add warning for description of absolute path in Windows