### PR TITLE
[CUBRIDMAN-257] Reflect changes in DEADLOCK (event log).

### DIFF
--- a/en/admin/control.rst
+++ b/en/admin/control.rst
@@ -777,7 +777,7 @@ When a deadlock occurs, lock information of that transaction is written into the
     
     wait:
         client: public@testhost|csql(21529)
-        lock: X_LOCK (oid=0|650|6, table=t)
+        lock: X_LOCK (oid=0|650|5, table=t)
         sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
         bind: 4
         bind: 2
@@ -791,7 +791,7 @@ When a deadlock occurs, lock information of that transaction is written into the
 
     wait:
         client: public@testhost|csql(21541) (Deadlock Victim)
-        lock: X_LOCK (oid=0|650|5, table=t)
+        lock: X_LOCK (oid=0|650|6, table=t)
         sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
         bind: 3
         bind: 1

--- a/en/admin/control.rst
+++ b/en/admin/control.rst
@@ -766,57 +766,49 @@ On the above, you can indicate the blocker which brought lock timeout and the wa
 When a deadlock occurs, lock information of that transaction is written into the event log. The following is an output example.
  
 ::
- 
-    02/02/16 20:56:17.638 - DEADLOCK
-    client: public@testhost|csql(21541)
-    hold:
-      lock:    X_LOCK (oid=0|650|5, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1 
-      bind: 3
-      bind: 1
- 
-      lock:    X_LOCK (oid=0|650|3, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1 
-      bind: 3
-      bind: 1
- 
-    wait:
-      lock:    X_LOCK (oid=0|650|4, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1 
-      bind: 5
-      bind: 2
- 
-    client: public@testhost|csql(21529)
-    hold:
-      lock:    X_LOCK (oid=0|650|6, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1 
-      bind: 4
-      bind: 2
- 
-      lock:    X_LOCK (oid=0|650|4, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1 
-      bind: 4
-      bind: 2
- 
-    wait:
-      lock:    X_LOCK (oid=0|650|3, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1 
-      bind: 6
-      bind: 1
- 
-*   client: <DB user>@<application client host name>|<process name>(<process ID>)
 
-    *   hold: an object which is acquiring a lock
+    02/02/16 20:56:17.638 - DEADLOCK
+    hold:
+        client: public@testhost|csql(21541) (Deadlock Victim)
+        lock: X_LOCK (oid=0|650|5, table=t)
+        sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
+        bind: 3
+        bind: 1
     
-        *   lock: lock type, table name
-        *   sql: SQL which is acquiring locks
-        *   bind: binding value
-        
-    *   wait: an object which is waiting a lock
-    
-        *   lock: lock type, table name
-        *   sql: SQL which is waiting a lock
-        *   bind: binding value
+    wait:
+        client: public@testhost|csql(21529)
+        lock: X_LOCK (oid=0|650|6, table=t)
+        sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
+        bind: 4
+        bind: 2
+
+    hold:
+        client: public@testhost|csql(21529)
+        lock: X_LOCK (oid=0|650|6, table=t)
+        sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
+        bind: 4
+        bind: 2
+
+    wait:
+        client: public@testhost|csql(21541) (Deadlock Victim)
+        lock: X_LOCK (oid=0|650|5, table=t)
+        sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
+        bind: 3
+        bind: 1
+
+*   hold: an object which is acquiring a lock
+
+    *   client: <DB user>@<application client host name>|<process name>(<process ID>)
+    *   lock: lock type, table name
+    *   sql: SQL which is acquiring locks
+    *   bind: binding value
+
+*   wait: an object which is waiting a lock
+
+    *   client: <DB user>@<application client host name>|<process name>(<process ID>)
+    *   lock: lock type, table name
+    *   sql: SQL which is waiting a lock
+    *   bind: binding value
  
 On the above output, you can check the application clients and SQLs which brought the deadlock.
       

--- a/en/admin/control.rst
+++ b/en/admin/control.rst
@@ -780,21 +780,21 @@ When a deadlock occurs, lock information of that transaction is written into the
         lock: X_LOCK (oid=0|650|5, table=t)
         sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
         bind: 4
-        bind: 2
+        bind: 1
 
     hold:
         client: public@testhost|csql(21529)
         lock: X_LOCK (oid=0|650|6, table=t)
         sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
-        bind: 4
+        bind: 5
         bind: 2
 
     wait:
         client: public@testhost|csql(21541) (Deadlock Victim)
         lock: X_LOCK (oid=0|650|6, table=t)
         sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
-        bind: 3
-        bind: 1
+        bind: 6
+        bind: 2
 
 *   hold: an object which is acquiring a lock
 

--- a/ko/admin/control.rst
+++ b/ko/admin/control.rst
@@ -770,7 +770,7 @@ I/O 읽기를 많이 발생시킨 질의를 기록한다. cubrid.conf의 **sql_t
     
     wait:
         client: public@testhost|csql(21529)
-        lock: X_LOCK (oid=0|650|6, table=t)
+        lock: X_LOCK (oid=0|650|5, table=t)
         sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
         bind: 4
         bind: 2
@@ -784,7 +784,7 @@ I/O 읽기를 많이 발생시킨 질의를 기록한다. cubrid.conf의 **sql_t
 
     wait:
         client: public@testhost|csql(21541) (Deadlock Victim)
-        lock: X_LOCK (oid=0|650|5, table=t)
+        lock: X_LOCK (oid=0|650|6, table=t)
         sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
         bind: 3
         bind: 1

--- a/ko/admin/control.rst
+++ b/ko/admin/control.rst
@@ -761,56 +761,48 @@ I/O 읽기를 많이 발생시킨 질의를 기록한다. cubrid.conf의 **sql_t
 ::
 
     02/02/16 20:56:17.638 - DEADLOCK
-    client: public@testhost|csql(21541)
     hold:
-      lock:    X_LOCK (oid=0|650|5, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1 
-      bind: 3
-      bind: 1
-
-      lock:    X_LOCK (oid=0|650|3, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1 
-      bind: 3
-      bind: 1
- 
+        client: public@testhost|csql(21541) (Deadlock Victim)
+        lock: X_LOCK (oid=0|650|5, table=t)
+        sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
+        bind: 3
+        bind: 1
+    
     wait:
-      lock:    X_LOCK (oid=0|650|4, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1 
-      bind: 5
-      bind: 2
- 
-    client: public@testhost|csql(21529)
+        client: public@testhost|csql(21529)
+        lock: X_LOCK (oid=0|650|6, table=t)
+        sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
+        bind: 4
+        bind: 2
+
     hold:
-      lock:    X_LOCK (oid=0|650|6, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
-      bind: 4
-      bind: 2
+        client: public@testhost|csql(21529)
+        lock: X_LOCK (oid=0|650|6, table=t)
+        sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
+        bind: 4
+        bind: 2
 
-      lock:    X_LOCK (oid=0|650|4, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
-      bind: 4
-      bind: 2
- 
     wait:
-      lock:    X_LOCK (oid=0|650|3, table=t)
-      sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
-      bind: 6
-      bind: 1
+        client: public@testhost|csql(21541) (Deadlock Victim)
+        lock: X_LOCK (oid=0|650|5, table=t)
+        sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
+        bind: 3
+        bind: 1
  
-*   client: <DB 사용자>@<응용 클라이언트 호스트 명>|<프로세스 이름>(<프로세스 ID>)
+*   hold: 잠금을 소유하고 있는 객체
 
-    *   hold: 잠금을 소유하고 있는 객체
-    
-        *   lock: 잠금 종류, 테이블 이름
-        *   sql: 잠금을 소유하고 있는 SQL
-        *   bind: 바인딩된 값
-        
-    *   wait: 잠금을 대기하고 있는 객체
-    
-        *   lock: 잠금 종류, 테이블 이름
-        *   sql: 잠금을 대기하고 있는 SQL
-        *   bind: 바인딩된 값
- 
+    *   client: <DB 사용자>@<응용 클라이언트 호스트 명>|<프로세스 이름>(<프로세스 ID>) (Deadlock Victim)
+    *   lock: 잠금 종류, 테이블 이름
+    *   sql: 잠금을 소유하고 있는 SQL
+    *   bind: 바인딩된 값
+
+*   wait: 잠금을 대기하고 있는 객체
+
+    *   client: <DB 사용자>@<응용 클라이언트 호스트 명>|<프로세스 이름>(<프로세스 ID>) (Deadlock Victim)
+    *   lock: 잠금 종류, 테이블 이름
+    *   sql: 잠금을 대기하고 있는 SQL
+    *   bind: 바인딩된 값
+
 위에서 교착 상태를 유발한 응용 클라이언트들과 SQL을 확인할 수 있다.
       
 잠금(lock)에 대한 자세한 설명은 :ref:`lockdb`\ 과 :ref:`lock-protocol`\ 을 참고한다.

--- a/ko/admin/control.rst
+++ b/ko/admin/control.rst
@@ -773,21 +773,21 @@ I/O 읽기를 많이 발생시킨 질의를 기록한다. cubrid.conf의 **sql_t
         lock: X_LOCK (oid=0|650|5, table=t)
         sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
         bind: 4
-        bind: 2
+        bind: 1
 
     hold:
         client: public@testhost|csql(21529)
         lock: X_LOCK (oid=0|650|6, table=t)
         sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
-        bind: 4
+        bind: 5
         bind: 2
 
     wait:
         client: public@testhost|csql(21541) (Deadlock Victim)
         lock: X_LOCK (oid=0|650|6, table=t)
         sql: update [t] [t] set [t].[a]= ?:0  where [t].[a]= ?:1
-        bind: 3
-        bind: 1
+        bind: 6
+        bind: 2
  
 *   hold: 잠금을 소유하고 있는 객체
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-257

DEADLOCK 발생 시 cycle에 참여한 모든 트랜잭션의 모든 잠금을 출력하던 방식에서 cycle에 기여한 잠금만 출력하도록 변경되었습니다. ([CBRD-25590](http://jira.cubrid.org/browse/CBRD-25590)에서 변경됨.)
해당 변경에 따라 메뉴얼에 변경점을 기록합니다.