### PR TITLE
[CBRD-25415] DBMS_OUTPUT messages follows CSQL messages.

### DIFF
--- a/ko/csql.rst
+++ b/ko/csql.rst
@@ -1405,9 +1405,13 @@ OPT LEVEL의 상세한 내용은 :ref:`viewing-query-plan`\ 를 참고한다.
 **서버 저장 메시지 출력(;SERver-output)**
 
 이 값을 ON으로 설정하면 서버의 DBMS_OUTPUT 버퍼에 저장된 메시지를 출력한다. 기본값은 OFF이다.
-DBMS_OUTPUT 버퍼는 주로 PL/CSQL 저장 프로시저/함수에서 DBMS_OUTPUT.put_line() 호출을 통해 쌓인 메시지들을 저장하고 있다.
-DBMS_OUTPUT 메시지들은 CSQL이 실행한 SQL 문의 결과 출력 후에 '<DBMS_OUTPUT>'  표시와 함께 출력된다.
-저장프로시스에서 오류 발생시 DBMS_OUTPUT.put_line()으로 출력한 메세지들은 실행 순서와 관계없이 에러메시지 출력 후 출력되므로 주의가 필요하다.
+DBMS_OUTPUT 버퍼는 PL/CSQL 저장 프로시저/함수에서 DBMS_OUTPUT.put_line()이나 DBMS_OUTPUT.put()
+호출을 통해 쌓인 메시지들을 저장하고 있다.
+실행한 SQL 문의 결과 출력 후에 '<DBMS_OUTPUT>' 표시 아래에 DBMS_OUTPUT 메시지들을 출력한다.
+이 때, 저장 프로시저/함수 실행 도중에 오류가 발생하면 실행문 순서와 상관없이
+에러 메시지를 포함한 CSQL의 기본 메시지들을 모두 출력한 다음 DBMS_OUTPUT 메세지들을 출력하므로 주의가 필요하다.
+예를 들어, 아래에서 DBMS_OUTPUT.put_line() 문은 ZERO_DIVIDE 예외를 일으키는 RETURN 문 이전에 실행되지만,
+출력에서는 DBMS_OUTPUT 메시지가 에러 메시지보다 나중에 위치한다.  ::
 
     csql> ;server-output on
     SERVER OUTPUT IS ON

--- a/ko/csql.rst
+++ b/ko/csql.rst
@@ -1402,6 +1402,8 @@ OPT LEVEL의 상세한 내용은 :ref:`viewing-query-plan`\ 를 참고한다.
     csql> ;time
     TIME IS ON
 
+.. _server-output:
+
 **서버 저장 메시지 출력(;SERver-output)**
 
 이 값을 ON으로 설정하면 서버의 DBMS_OUTPUT 버퍼에 저장된 메시지를 출력한다. 기본값은 OFF이다.

--- a/ko/pl/pl.rst
+++ b/ko/pl/pl.rst
@@ -34,21 +34,6 @@ PL/CSQL은 저장 프로시저나 저장 함수를 생성하는데 사용된다.
 저장 프로시저/함수는 :ref:`큐브리드 내장 함수 <operators-and-functions>`\와 동일한 이름을 가질 수 없다.
 동일한 이름으로 선언하면 컴파일 과정에서 (CREATE 문 실행 과정에서) 에러가 발생한다.
 
-body 내부의 실행문들 중 수행시 도달할 수 없는 실햄문이 있는 경우 컴파일 과정에서 에러를 발생한다.
-다음은 도달할 수 없는 실행문이 있는 간단한 예이다.
-
-.. code-block:: sql
-
-    csql> CREATE OR REPLACE PROCEDURE test_unreachable_statement
-    csql> AS
-    csql> BEGIN
-    csql>     RETURN;
-    csql>     DBMS_OUTPUT.put_line('Hello world');
-    csql> END;
-
-    ERROR: In line 5, column 5
-    Stored procedure compile error: unreachable statement
-
 다음은 PL/CSQL을 사용해서 작성한 저장 프로시저/함수의 예이다.
 
 .. code-block:: sql
@@ -1293,6 +1278,21 @@ BLOCK에서 선언된 아이템이 바깥 scope에서 선언된 다른 아이템
 
         DBMS_OUTPUT.put_line(a || b || c);          -- '333'
     END;
+
+body 내부의 실행문들 중 수행시 도달할 수 없는 실햄문이 있는 경우 컴파일 과정에서 에러를 발생한다.
+다음은 도달할 수 없는 실행문이 있는 간단한 예이다.
+
+.. code-block:: sql
+
+    csql> CREATE OR REPLACE PROCEDURE test_unreachable_statement
+    csql> AS
+    csql> BEGIN
+    csql>     RETURN;
+    csql>     DBMS_OUTPUT.put_line('Hello world');
+    csql> END;
+
+    ERROR: In line 5, column 5
+    Stored procedure compile error: unreachable statement
 
 Static SQL
 ==========

--- a/ko/pl/pl.rst
+++ b/ko/pl/pl.rst
@@ -42,8 +42,8 @@ body 내부의 실행문들 중 수행시 도달할 수 없는 실햄문이 있�
     csql> CREATE OR REPLACE PROCEDURE test_unreachable_statement
     csql> AS
     csql> BEGIN
-    csql>     return;
-    csql>     dbms_output.put_line('Hello world');
+    csql>     RETURN;
+    csql>     DBMS_OUTPUT.put_line('Hello world');
     csql> END;
 
     ERROR: In line 5, column 5

--- a/ko/pl/pl.rst
+++ b/ko/pl/pl.rst
@@ -94,6 +94,11 @@ PL/CSQL은 저장 프로시저나 저장 함수를 생성하는데 사용된다.
             RETURN -1;
     END;
 
+위 예제들에서 DBMS_OUTPUT.put_line() 문은 인자로 주어진 문자열을 서버의 DBMS_OUTPUT 버퍼에 저장한다.
+인자가 문자열 타입이 아닐 때는 문자열로 형변환한 값을 저장한다.
+DBMS_OUTPUT 버퍼에 저장된 문자열 메시지들은 CSQL에서 세션 명령어 ;server-output on을 실행해서 확인할 수 있다.
+자세한 내용은 :ref:`CSQL 세션명령어 server-output <server-output>`\을 참조한다.
+
 CREATE PROCEDURE/FUNCTION 문을 실행하면 저장 프로시저/함수의 문법과 실행 의미에 관련된 각종 규칙들을 검사한다.
 검사에서 오류가 발견되면 발생된 위치와 원인을 설명하는 오류 메세지를 출력한다.
 다음은 오류를 가지고 있는 저장 프로시저가 CSQL에서 에러를 발생시키는 예이다.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-25415

이슈에서 구현했던 내용 중 DBMS_OUTPUT 메시지가 
CSQL 메시지 다음에 <DBMS_OUTPUT> 표시 아래에 표시됨을 설명.

;server-output 세션명령어에 대한 help 메시지나 설명은 기존에 추가되어 있었음.

이슈와 관련 없는 변경이지만, 
unreachable statement 에 대한 설명을 도입부에서 BLOCK 섹션으로 옮겼음.