### PR TITLE
[CUBRIDMAN-260] Change the description of 'Creation_time' displayed when using the 'SHOW' statement to refer to the volume creation time instead of the database creation time

### DIFF
--- a/en/sql/query/show.rst
+++ b/en/sql/query/show.rst
@@ -673,7 +673,7 @@ Sector_alloc_table_first_page       INT             First page of sector allocat
 Page_alloc_table_size_in_pages      INT             Size of page allocation table in page
 Page_alloc_table_first_page         INT             First page of page allocation table
 Last_system_page                    INT             Last system page
-Creation_time                       DATETIME        Database creation time
+Creation_time                       DATETIME        Volume creation time
 Db_charset                          INT             Charset number of database
 Checkpoint_lsa                      VARCHAR(64)     Lowest log sequence address to start the recovery process of this volume
 Boot_hfid                           VARCHAR(64)     System Heap file for booting purposes and multi volumes
@@ -733,7 +733,7 @@ Column name                         Type            Description
 Volume_id                           INT             Volume identifier
 Magic_symbol                        VARCHAR(32)     Magic value for log file
 Magic_symbol_location               INT             Magic symbol location from log page
-Creation_time                       DATETIME        Database creation time
+Creation_time                       DATETIME        Volume creation time
 Release                             VARCHAR(32)     CUBRID Release version
 Compatibility_disk_version          VARCHAR(32)     Compatibility of the database against the current release of CUBRID
 Db_page_size                        INT             Size of pages in the database
@@ -886,7 +886,7 @@ Column name                         Type            Description
 Volume_id                           INT             Identifier of log volume
 Magic_symbol                        VARCHAR(32)     Magic value for file/magic Unix utility
 Magic_symbol_location               INT             Magic symbol location from log page
-Creation_time                       DATETIME        Database creation time
+Creation_time                       DATETIME        Volume creation time
 Next_trans_id                       BIGINT          Next transaction identifier
 Num_pages                           INT             Number of pages in the archive log
 First_page_id                       BIGINT          Logical page id at physical location 1 in archive log

--- a/ko/sql/query/show.rst
+++ b/ko/sql/query/show.rst
@@ -674,7 +674,7 @@ Sector_alloc_table_first_page       INT             섹터 할당 테이블의 �
 Page_alloc_table_size_in_pages      INT             페이지 내 페이지 할당 테이블의 크기
 Page_alloc_table_first_page         INT             페이지 할당 테이블의 첫번째 페이지
 Last_system_page                    INT             마지막 시스템 페이지
-Creation_time                       DATETIME        데이터베이스 생성 시간
+Creation_time                       DATETIME        볼륨 생성 시간
 Db_charset                          INT             데이터베이스 문자셋번호 
 Checkpoint_lsa                      VARCHAR(64)     이 볼륨의 복구 절차를 시작하는 가장 작은 로그 일련 주소
 Boot_hfid                           VARCHAR(64)     다중 볼륨과 데이터베이스 기동을 위한 시스템 힙 파일ID
@@ -734,7 +734,7 @@ Column name                         Type            Description
 Volume_id                           INT             볼륨 식별자
 Magic_symbol                        VARCHAR(32)     로그 파일의 매직 값
 Magic_symbol_location               INT             로그 페이지의 매직 심볼 위치
-Creation_time                       DATETIME        데이터베이스 생성 시간
+Creation_time                       DATETIME        볼륨 생성 시간
 Release                             VARCHAR(32)     CUBRID 릴리즈 버전
 Compatibility_disk_version          VARCHAR(32)     현재 릴리즈 버전에 대한 DB의 호환성
 Db_page_size                        INT             DB 페이지의 크기
@@ -887,7 +887,7 @@ SHOW ARCHIVE LOG HEADER
 Volume_id                           INT             로그 볼륨 ID
 Magic_symbol                        VARCHAR(32)     보관 로그 파일의 매직 값
 Magic_symbol_location               INT             로그 페이지로부터 매직 심볼 위치
-Creation_time                       DATETIME        DB 생성 시간
+Creation_time                       DATETIME        볼륨 생성 시간
 Next_trans_id                       BIGINT          다음 트랜잭션 ID
 Num_pages                           INT             보관 로그에서 페이지의 개수
 First_page_id                       BIGINT          보관 로그에서 물리적 위치 1에 대한 논리 페이지 ID


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-260

CBRD-25365 이슈에 의해 Creation_time의 의미가 변경되었습니다.

기존 Creation_time은 데이터베이스 생성시간이였으나 볼륨 생성시간으로 변경됨에 따라 매뉴얼의 내용을 수정합니다.

변경사항은 아래 url에서 확인 가능합니다.

ko : [192.168.2.101:9000](http://192.168.2.101:9000/sql/query/show.html)
en : [192.168.2.101:9001](http://192.168.2.101:9001/sql/query/show.html)