### PR TITLE
[CUBRIDMAN-264] Adds an explanation about the id of the SQL log

### DIFF
--- a/en/ha.rst
+++ b/en/ha.rst
@@ -796,6 +796,7 @@ The default is **no**.
 The format of this log file name is *<db name>_<master hostname>*\ **.sql.log.**\ *<id>*, and *<id>* starts from 0.
 If this size is over **ha_sql_log_max_size_in_mbytes**, a new file with "*<id>* + 1" is created.
 For example, if "ha_sql_log_max_size_in_mbytes=100", demodb_nodeA.sql.log.1 is newly created as the size of demodb_nodeA.sql.log.0 file becomes 100MB.
+*<id>* will wrap around to 0 once it exceeds the maximum value (4,294,967,295).
 
 By default, only two latest SQL log files are maintained, and the maximum number of them can be adjusted through **ha_sql_log_max_count**.
 

--- a/ko/ha.rst
+++ b/ko/ha.rst
@@ -795,6 +795,7 @@ SQL 로깅
 로그 파일 이름의 형식은 *<db name>_<master hostname>*\ **.sql.log.**\ *<id>*\ 이며, *<id>*\ 는 0부터 시작한다. 
 **ha_sql_log_max_size_in_mbytes**\에서 지정한 크기를 초과하면 *<id>*\ 의 값이 하나 증가된 새로운 파일이 생성된다.
 예를 들어, "ha_sql_log_max_size_in_mbytes=100"이면 demodb_nodeA.sql.log.0 파일이 100MB가 되면서 demodb_nodeA.sql.log.1이 새로 생성된다.
+*<id>*\ 는 최대값(4294967295)을 초과하게 되면 0부터 재사용하게 된다.
 
 기본적으로, 2개의 최신 SQL 로그 파일만 유지되며, **ha_sql_log_max_count** 설정을 통해 유지할 최대 파일 개수를 조정할 수 있다.
 

--- a/ko/ha.rst
+++ b/ko/ha.rst
@@ -795,7 +795,7 @@ SQL 로깅
 로그 파일 이름의 형식은 *<db name>_<master hostname>*\ **.sql.log.**\ *<id>*\ 이며, *<id>*\ 는 0부터 시작한다. 
 **ha_sql_log_max_size_in_mbytes**\에서 지정한 크기를 초과하면 *<id>*\ 의 값이 하나 증가된 새로운 파일이 생성된다.
 예를 들어, "ha_sql_log_max_size_in_mbytes=100"이면 demodb_nodeA.sql.log.0 파일이 100MB가 되면서 demodb_nodeA.sql.log.1이 새로 생성된다.
-*<id>*\ 는 최대값(4294967295)을 초과하게 되면 0부터 재사용하게 된다.
+*<id>*\ 는 최대값(4,294,967,295)을 초과하게 되면 0부터 재사용하게 된다.
 
 기본적으로, 2개의 최신 SQL 로그 파일만 유지되며, **ha_sql_log_max_count** 설정을 통해 유지할 최대 파일 개수를 조정할 수 있다.
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-264

기존에는 sql_log의 id가 MAX값을 넘어서면 음수가 되어버렸는데
CBRD-24738 이슈로 인해 0부터 재사용하도록 변경되었습니다.

위 내용을 매뉴얼에 추가합니다.

변경사항은 아래 url에서 확인 가능합니다.

ko : [192.168.2.104:9000](http://192.168.2.104:9000/ha.html#sql)
en : [192.168.2.104:9001](http://192.168.2.104:9001/ha.html#sql)