### PR TITLE
[CUBRIDMAN-249] [KO] The manual is updated with changes to the specifications for granting and revoking permissions (grant/revoke).

### DIFF
--- a/ko/sql/authorization.rst
+++ b/ko/sql/authorization.rst
@@ -295,8 +295,8 @@ REVOKE
 
     REVOKE ALL PRIVILEGES ON nation, athlete FROM smith;
 
-다음은 *u1* 사용자가 *tbl1*에 대해 *u2* 사용자에게 **WITH GRANT OPTION**과 함께 **SELECT**권한을 부여하고, *u2* 사용자는 *u3* 사용자에게 *tbl1* 테이블의 **SELECT** 권한 부여한 후, *DBA* 가 *u1*사용자의 *tbl1*에 부여된 *u2* 의 권한을 해지하는 예시이다.
-*tbl1*에 대한 *u2*의 권한 해지시, *u2*가 **WITH GRANT OPTION**을 이용해서 부여한 권한에 대해서도 함께 해지된다.
+다음은 *u1* 사용자가 *tbl1*에 대해 *u2* 사용자에게 **WITH GRANT OPTION** 과 함께 **SELECT** 권한을 부여하고, *u2* 사용자는 *u3* 사용자에게 *tbl1* 테이블의 **SELECT** 권한 부여한 후, *DBA* 가 *u1* 사용자의 *tbl1* 에 부여된 *u2* 의 권한을 해지하는 예시이다.
+*tbl1* 에 대한 *u2* 의 권한 해지시, *u2* 가 **WITH GRANT OPTION** 을 이용해서 부여한 권한에 대해서도 함께 해지된다.
 
 .. code-block:: sql
     


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-249

권한 부여/회수(grant/revoke)에 대한 스펙 변경으로 매뉴얼을 수정합니다.

1. 권한 해지(Revoke) 시 Cascade 동작이 정상적으로 실행되지 않는 문제 해결
2. 최고 관리자(DBA) 및 멤버(Owner, DBA)가 권한을 부여/회수(grant/revoke)할 때 소유자로 동작하도록 처리
3. WITH GRANT OPTION 권한을 부여받은 그룹의 멤버는 부여받은 권한을 다른 사용자에게 부여할 수 없다. 