### PR TITLE
[CUBRIDMAN-283] Add hot reloading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Documentation for CUBRID RDBMS
     make html
     ```
 
+   - Hot reloading
+        ```
+        // change directory to en or ko
+        make livehtml
+        ```
+        For details about hot reloading, see https://github.com/sphinx-doc/sphinx-autobuild
+
 5. Mainly used tags on sphinx document(.rst file).
 
    Basically, indent is very important when you use tags. For details, see http://sphinx-doc.org/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Documentation for CUBRID RDBMS
       1. Install read the docs theme
 
          ```
-         pip3 install sphinx_rtd_theme
+         pip3 install sphinx_rtd_theme sphinx-autobuild
          ```
 
       1. Install make to build

--- a/en/Makefile
+++ b/en/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+SPHINXAUTOBUILD   = sphinx-autobuild
 PAPER         =
 BUILDDIR      = _build
 
@@ -14,11 +15,12 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: help clean html livehtml dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "  livehtml   to start a live-reloading documentation server (auto-refresh on changes)"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -45,6 +47,9 @@ html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+livehtml:
+	$(SPHINXAUTOBUILD) $(ALLSPHINXOPTS) $(BUILDDIR)/html
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/ko/Makefile
+++ b/ko/Makefile
@@ -4,6 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
+SPHINXAUTOBUILD   = sphinx-autobuild
 PAPER         =
 BUILDDIR      = _build
 
@@ -14,11 +15,12 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: help clean html livehtml dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  html       to make standalone HTML files"
+	@echo "  livehtml   to start a live-reloading documentation server (auto-refresh on changes)"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
 	@echo "  pickle     to make pickle files"
@@ -45,6 +47,9 @@ html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+livehtml:
+	$(SPHINXAUTOBUILD) $(ALLSPHINXOPTS) $(BUILDDIR)/html
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml


### PR DESCRIPTION
[http://jira.cubrid.org/browse/CUBRIDMAN-283](http://jira.cubrid.org/browse/CUBRIDMAN-283)

현재 CUBRID 매뉴얼 작성 시, 매뉴얼 수정 후 빌드를 수행하며 작업하는 것으로 알고 있습니다. 이는 수정 사항을 즉각적으로 확인할 수 없고, 수정 사항을 확인할 때마다 빌드 시간이 소요되기 때문에 비효율적입니다. 따라서 이를 개선하고자 hot reloading 기능을 추가했습니다.

Hot reloading이란?
Hot reloading은 파일의 변경이 감지되었을 때, 변경된 파일만 업데이트해서 보여주는 기능입니다. 이와 비슷한 기능으로 Live reloading이 있는데, Live reloading은 앱 전체를 재시작하여 업데이트된 내용을 보여주는 기능입니다.

CUBRID는 현재 html 생성을 위해 sphinx-build를 사용하고 있습니다. 따라서 [sphinx 공식 문서](https://www.sphinx-doc.org/en/master/index.html)에 나와있는 [sphinx-autobuild](https://www.sphinx-doc.org/en/master/usage/quickstart.html#running-the-build)를 사용했습니다.