### PR TITLE
[CUBRIDMAN-289] Update JDBC function description for oracle_compat_number_behavior

### DIFF
--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -1619,14 +1619,23 @@ The following are parameters related to SQL statements and data types supported 
         ==========
                0.5
 
-    .. note:: 
+    .. note::
 
-        The oracle_compat_number_behavior is only applied, when reading NUMERIC, DOUBLE, and FLOAT type data in string format in JDBC/CCI.  The related functions of JDBC/CCI are as follows.
+        The following JDBC/CCI functions are affected by the oracle_compat_number_behavior setting:
 
-        * JDBC : getString(int columnIndex), getString(String columnLabel), getObject(int columnIndex) , getObject(String columnLabel)
+        **JDBC**
 
-        * CCI :  cci_get_data (CCI_A_TYPE_STR as type), Example) cci_get_data(req, i, CCI_A_TYPE_STR, &data, &ind)
-		 
+        getString(int columnIndex), getString(String columnLabel)
+            *   Data Types Affected: NUMERIC, DOUBLE, FLOAT
+
+        getObject(int columnIndex), getObject(String columnLabel)
+            *   Data Types Affected: NUMERIC
+
+        **CCI**
+
+        cci_get_data(CCI_A_TYPE_STR as type), Example) cci_get_data(req, i, CCI_A_TYPE_STR, &data, &ind)
+            *   Data Types Affected: NUMERIC, DOUBLE, FLOAT
+
 .. _oracle_style_empty_string:
 
 **oracle_style_empty_string**

--- a/ko/admin/config.rst
+++ b/ko/admin/config.rst
@@ -1612,13 +1612,22 @@ CUBRID 설치 시 생성되는 기본 데이터베이스 환경 설정 파일(**
         ==========
                0.5
 
-    .. note:: 
+    .. note::
 
-        JDBC/CCI에서 NUMERIC, DOUBLE 및 FLOAT 타입의 데이터를 문자열 형태로 읽을 경우만 oracle_compat_number_behavior 설정값이 적용된다. 아래는 설정값이 적용되는 JDBC/CCI함수이다.
-		
-        *   JDBC : getString(int columnIndex), getString(String columnLabel), getObject(int columnIndex), getObject(String columnLabel)
-		
-        *   CCI : cci_get_data(CCI_A_TYPE_STR type을 사용한 경우), 예) cci_get_data(req, i, CCI_A_TYPE_STR, &data, &ind)
+        oracle_compat_number_behavior 설정값이 적용되는 JDBC/CCI 함수는 다음과 같다.
+
+        **JDBC**
+
+        getString(int columnIndex), getString(String columnLabel)
+            *   적용 데이터 타입: NUMERIC, DOUBLE, FLOAT
+
+        getObject(int columnIndex), getObject(String columnLabel)
+            *   적용 데이터 타입: NUMERIC
+
+        **CCI**
+
+        cci_get_data(CCI_A_TYPE_STR 타입을 사용한 경우), 예: cci_get_data(req, i, CCI_A_TYPE_STR, &data, &ind)
+            *   적용 데이터 타입: NUMERIC, DOUBLE, FLOAT
 
 
 .. _oracle_style_empty_string:


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-289

**Purpose**
oracle_compat_number_behavior 설정 시 **JDBC getObject** 메소드에 적용되는 데이터 타입이 기존에는 NUMERIC, DOUBLE, FLOAT이었으나, **NUMERIC만 적용**되도록 수정되었습니다.
이에 매뉴얼 내용을 업데이트합니다.

**Remarks**
http://jira.cubrid.org/browse/APIS-1028