### PR TITLE
[CUBRIDMAN-234] Writing a manual for the ACCESS_CONTROL_DEFAULT_POLICY parameter

### DIFF
--- a/en/admin/config.rst
+++ b/en/admin/config.rst
@@ -2446,6 +2446,8 @@ The following table shows the broker parameters available in the broker configur
 | :ref:`broker-common-parameters` | Access                  | ACCESS_CONTROL                          | bool   | no                           |           |
 |                                 |                         +-----------------------------------------+--------+------------------------------+-----------+
 |                                 |                         | ACCESS_CONTROL_FILE                     | string |                              |           |
+|                                 |                         +-----------------------------------------+--------+------------------------------+-----------+
+|                                 |                         | ACCESS_CONTROL_DEFAULT_POLICY           | bool   | DENY                         |           |
 |                                 +-------------------------+-----------------------------------------+--------+------------------------------+-----------+
 |                                 | Logging                 | ADMIN_LOG_FILE                          | string | log/broker/cubrid_broker.log |           |
 |                                 +-------------------------+-----------------------------------------+--------+------------------------------+-----------+
@@ -2471,8 +2473,6 @@ The following table shows the broker parameters available in the broker configur
 |                                 |                         | RECONNECT_TIME                          | sec    | 600                          | available |
 |                                 |                         +-----------------------------------------+--------+------------------------------+-----------+
 |                                 |                         | REPLICA_ONLY                            | string | OFF                          |           |
-|                                 |                         +-----------------------------------------+--------+------------------------------+-----------+
-|                                 |                         | ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER | bool   | DENY                         |           |
 |                                 +-------------------------+-----------------------------------------+--------+------------------------------+-----------+
 |                                 | Broker App. Server(CAS) | APPL_SERVER_MAX_SIZE                    | MB     | Windows 32bit: 40,           | available |
 |                                 |                         |                                         |        | Windows 64bit: 80,           |           |
@@ -2641,6 +2641,14 @@ Access
 
     **ACCESS_CONTROL_FILE** is a parameter to configure the name of a file in which a database name, database user ID, and the list of IPs are stored. List of IPs can be written up to the maximum of 256 lines per <*db_name*>:<*db_user*> in a broker. For details, see :ref:`limiting-broker-access`.
 
+**ACCESS_CONTROL_DEFAULT_POLICY**
+
+    If no broker is specified in the **ACCESS_CONTROL_FILE** and the value of **ACCESS_CONTROL_DEFAULT_POLICY** is **ALLOW**, access to the broker is permitted for everyone. The default is **DENY**. For more information, see :ref:`limiting-broker-access`.
+
+    .. note::
+    
+       The settings value ALLOW or DENY for **ACCESS_CONTROL_DEFAULT_POLICY** is valid only when **ACCESS_CONTROL** is set to **ON**. If it is set to **OFF**, the setting value is not applicable.
+
 Logging
 ^^^^^^^
 
@@ -2724,15 +2732,6 @@ Access
     
         Please note that replication mismatch occurs when you write the data directly to the replica DB.
 
-.. _access_control_behavior_for_emptybroker:
-
-**ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER**	
-	
-    If no broker is specified in **ACCESS_CONTROL_FILE** and the value of **ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER** is **ALLOW** , all access to the broker are allowed. The default is **DENY**. For more information, see :ref:`limiting-broker-access`.
-
-    .. note::
-    
-       The settings value ALLOW or DENY for **ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER** is valid only when **ACCESS_CONTROL** is set to **ON**. If it is set to **OFF**, the setting value is not applicable.
 	
 Broker App. Server(CAS)
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/en/admin/control.rst
+++ b/en/admin/control.rst
@@ -1462,8 +1462,9 @@ Limiting Broker Access
 ----------------------
 
 To limit the client applications accessing the broker, set to **ON** for the **ACCESS_ CONTROL** parameter in the **cubrid_broker.conf** file, and enter a name of the file in which the users and the list of databases and IP addresses allowed to access the **ACCESS_CONTROL_FILE** parameter value are written. 
-The default value of the **ACCESS_CONTROL** broker parameter is **OFF**. All access to brokers not listed in **ACCESS_CONTROL_FILE** is restricted. Even if not listed in **ACCESS_CONTROL_FILE**, you can allow access to a specific broker by setting **ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER** to **ALLOW** for that broker.
-The **ACCESS_CONTROL** and **ACCESS_CONTROL_FILE** parameters must be written under the [broker] section where common parameters are specified. On the other hand, the **ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER** parameter must be specified for each broker.
+If a broker name is not listed in the ACCESS_CONTROL_FILE, access to that broker is determined by the **ACCESS_CONTROL_DEFAULT_POLICY** parameter. If this parameter is set to DENY, access is restricted; if set to ALLOW, access is permitted.
+The default value of the **ACCESS_CONTROL** broker parameter is **OFF**, and the default value of **ACCESS_CONTROL_DEFAULT_POLICY** is **DENY**.
+The **ACCESS_CONTROL**, **ACCESS_CONTROL_FILE**, and **ACCESS_CONTROL_DEFAULT_POLICY** parameters must be specified under the [broker] section, where common parameters are defined.
 
 The format of **ACCESS_CONTROL_FILE** is as follows: 
 
@@ -1493,13 +1494,12 @@ The format of the ip_list_file is as follows:
 
 *   <ip_addr>: An IP address that is allowed to access the server. If the last digit of the address is specified as \*, all IP addresses in that rage are allowed to access the broker server.
 
-If a value for **ACCESS_CONTROL** is set to ON and a value for **ACCESS_CONTROL_FILE** is not specified, the broker will only allow the access requests from the localhost. 
-However, if **ACCESS_CONTROL_FILE** is not specified, all requests are allowed for brokers with **ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER** set to **ALLOW**.
+Even if the **ACCESS_CONTROL** value is set to ON, access from localhost is always allowed. (In other words, specifying the localhost IP (127.0.0.1) in the ip_list_file is ignored.)
 
 Broker access restrictions not specified in **ACCESS_CONTROL_FILE**.
 
 * Allow access only from localhost. (default)
-* If **ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER** is set to **ALLOW**, all access is allowed.
+* If **ACCESS_CONTROL_DEFAULT_POLICY** is set to **ALLOW**, all access is allowed.
 
 If the analysis of **ACCESS_CONTROL_FILE** and ip_list_file fails when starting a broker, the broker will not be run.  
 
@@ -1514,7 +1514,6 @@ If the analysis of **ACCESS_CONTROL_FILE** and ip_list_file fails when starting 
     [%QUERY_EDITOR]
     SERVICE                 =ON
     BROKER_PORT             =30000
-    ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER = ALLOW
     ......
 
 The following example shows the content of **ACCESS_CONTROL_FILE**. The * symbol represents everything, and you can use it when you want to specify database names, database user IDs and IPs in the IP list file which are allowed to access the broker server.  
@@ -1586,17 +1585,17 @@ The below is an example of displaying results.
     $ cubrid broker acl status 
     ACCESS_CONTROL=ON 
     ACCESS_CONTROL_FILE=access_file.txt 
-  
+    ACCESS_CONTROL_DEFAULT_POLICY=ALLOW
+    
     [%broker1] 
-    ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER=DENY
     demodb:dba:iplist1.txt 
            CLIENT IP LAST ACCESS TIME 
     ========================================== 
-        10.20.129.11 
+      10.20.129.11 
       10.113.153.144 2013-11-07 15:19:14 
       10.113.153.145 
       10.113.153.146 
-             10.64.* 2013-11-07 15:20:50 
+      10.64.* 2013-11-07 15:20:50 
   
     testdb:dba:iplist2.txt 
            CLIENT IP LAST ACCESS TIME 
@@ -1604,8 +1603,7 @@ The below is an example of displaying results.
                    * 2013-11-08 10:10:12 
     
     [%broker2]
-    ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER=ALLOW
-	
+ 	
     ++ cubrid broker acl: success
 	
 **Broker Logs**

--- a/ko/admin/config.rst
+++ b/ko/admin/config.rst
@@ -2614,7 +2614,7 @@ CUBRID 설치 시 생성되는 기본 브로커 설정 파일인 **cubrid_broker
 
 **ACCESS_CONTROL_DEFAULT_POLICY**
 
-	**ACCESS_CONTROL_DEFAULT_POLICY** 은 ACCESS_CONTROL_FILE에 지정한 브로커가 없고 **ACCESS_CONTROL_DEFAULT_POLICY** 의 값이 **ALLOW** 인 경우, 브로커에 접속을 모두 허용한다. 기본값은 **DENY** 이다.  자세한 내용은 :ref:`limiting-broker-access` 을 참고한다.
+    **ACCESS_CONTROL_FILE** 에 지정한 브로커가 없고 **ACCESS_CONTROL_DEFAULT_POLICY** 의 값이 **ALLOW** 인 경우, 브로커에 접속을 모두 허용한다. 기본값은 **DENY** 이다.  자세한 내용은 :ref:`limiting-broker-access` 을 참고한다.
 
     .. note::
     

--- a/ko/admin/config.rst
+++ b/ko/admin/config.rst
@@ -2418,6 +2418,8 @@ cubrid_broker.conf 설정 파일과 기본 제공 파라미터
 | :ref:`broker-common-parameters` | 접속                    | ACCESS_CONTROL                          | bool   | no                           |           |
 |                                 |                         +-----------------------------------------+--------+------------------------------+-----------+
 |                                 |                         | ACCESS_CONTROL_FILE                     | string |                              |           |
+|                                 |                         +-----------------------------------------+--------+------------------------------+-----------+
+|                                 |                         | ACCESS_CONTROL_DEFAULT_POLICY           | bool   | DENY                         |           |
 |                                 +-------------------------+-----------------------------------------+--------+------------------------------+-----------+
 |                                 | 로그                    | ADMIN_LOG_FILE                          | string | log/broker/cubrid_broker.log |           |
 |                                 +-------------------------+-----------------------------------------+--------+------------------------------+-----------+
@@ -2442,8 +2444,6 @@ cubrid_broker.conf 설정 파일과 기본 제공 파라미터
 |                                 |                         | RECONNECT_TIME                          | sec    | 600                          | 가능      |
 |                                 |                         +-----------------------------------------+--------+------------------------------+-----------+
 |                                 |                         | REPLICA_ONLY                            | string | OFF                          |           |
-|                                 |                         +-----------------------------------------+--------+------------------------------+-----------+
-|                                 |                         | ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER | bool   | DENY                         |           |
 |                                 +-------------------------+-----------------------------------------+--------+------------------------------+-----------+
 |                                 | 브로커 응용 서버(CAS)   | APPL_SERVER_MAX_SIZE                    | MB     | Windows 32비트: 40,          | 가능      |
 |                                 |                         |                                         |        | Windows 64비트: 80,          |           |
@@ -2612,6 +2612,15 @@ CUBRID 설치 시 생성되는 기본 브로커 설정 파일인 **cubrid_broker
 
     **ACCESS_CONTROL_FILE** 은 브로커에 접속을 허용하는 데이터베이스 이름, 데이터베이스 사용자 ID, IP 목록을 저장한 파일 이름을 지정하는 파라미터이다. IP 목록은 하나의 브로커 내에서 <*db_name*>:<*db_user*> 별로 최대 256 라인까지 작성될 수 있다.  자세한 내용은 :ref:`limiting-broker-access` 을 참고한다.
 
+**ACCESS_CONTROL_DEFAULT_POLICY**
+
+	**ACCESS_CONTROL_DEFAULT_POLICY** 은 ACCESS_CONTROL_FILE에 지정한 브로커가 없고 **ACCESS_CONTROL_DEFAULT_POLICY** 의 값이 **ALLOW** 인 경우, 브로커에 접속을 모두 허용한다. 기본값은 **DENY** 이다.  자세한 내용은 :ref:`limiting-broker-access` 을 참고한다.
+
+    .. note::
+    
+       **ACCESS_CONTROL_DEFAULT_POLICY** 의 설정값은 **ACCESS_CONTROL** 이 **ON** 일 때만 유효하며, **OFF** 일 경우에는 설정값이 적용되지 않는다.
+
+
 로그
 ^^^^
 
@@ -2695,15 +2704,6 @@ CUBRID 설치 시 생성되는 기본 브로커 설정 파일인 **cubrid_broker
     
         레플리카에 직접 데이터를 쓰는 경우 복제 불일치가 발생함에 주의해야 한다.
 
-.. _access_control_behavior_for_emptybroker:
-
-**ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER**	
-	
-    **ACCESS_CONTROL_FILE** 에 지정한 브로커가 없고 **ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER** 의 값이 **ALLOW** 인 경우, 브로커에 접속을 모두 허용한다. 기본값은 **DENY** 이다.  자세한 내용은 :ref:`limiting-broker-access` 을 참고한다.
-
-    .. note::
-    
-       **ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER** 의 설정값 **ALLOW** 또는 **DENY** 는 **ACCESS_CONTROL** 이 **ON** 일 때만 유효하며, **OFF** 일 경우에는 설정값이 적용되지 않습니다.
 
 브로커 응용 서버(CAS)
 ^^^^^^^^^^^^^^^^^^^^^

--- a/ko/admin/control.rst
+++ b/ko/admin/control.rst
@@ -1493,7 +1493,7 @@ ip_list_file의 작성 형식은 다음과 같다.
 **ACCESS_CONTROL_FILE** 에 지정되지 않은 브로커 접속 제한 방식.
 
 *  localhost에서만 접속 허용. (기본)
-*  ACCESS_CONTROL_DEFAULT_POLICY를 ALLOW 로 설정하면 모든 접속 허용.
+*  **ACCESS_CONTROL_DEFAULT_POLICY** 를 ALLOW 로 설정하면 모든 접속 허용.
 
 브로커 구동 시 **ACCESS_CONTROL_FILE** 및 ip_list_file 분석에 실패하는 경우 브로커는 구동되지 않는다. 
 

--- a/ko/admin/control.rst
+++ b/ko/admin/control.rst
@@ -1454,9 +1454,9 @@ SHARD-Q는 Shard Waiting Queue를 줄인 말이다. SHARD proxy 프로세스가 
 ---------------------
 
 브로커에 접속하는 응용 클라이언트를 제한하려면 **cubrid_broker.conf**\의 **ACCESS_CONTROL** 파라미터 값을 ON으로 설정하고, **ACCESS_CONTROL_FILE** 파라미터 값에 접속을 허용하는 사용자와 데이터베이스 및 IP 목록을 작성한 파일 이름을 입력한다.
-만약 ACCESS_CONTROL_FILE에 브로커 이름이 없으면, 해당 브로커로의 모든 접속이 제한된다. 이 경우, ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER 파라미터를 설정하여 모든 접속을 허용할 수 있다.
-**ACCESS_CONTROL** 브로커 파라미터의 기본값은 **OFF**\이다.
-**ACCESS_CONTROL**, **ACCESS_CONTROL_FILE** 파라미터는 공통 적용 파라미터가 위치하는 [broker] 아래에 작성해야 하며, **ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER** 파라미터는 각각의 브로커에 작성하야 한다.
+ACCESS_CONTROL_FILE에 브로커 이름이 없으면 해당 브로커로의 모든 접속이 제한된다. 이때, **ACCESS_CONTROL_DEFAULT_POLICY** 를 설정하면 모든 접속을 허용할 수 있다.
+**ACCESS_CONTROL** 브로커 파라미터의 기본값은 **OFF** , **ACCESS_CONTROL_DEFAULT_POLICY** 의 기본값은 **DENY** 이다.
+**ACCESS_CONTROL** , **ACCESS_CONTROL_FILE** , **ACCESS_CONTROL_DEFAULT_POLICY** 파라미터는 공통 파라미터가 지정되는 [broker] 섹션 아래에 작성해야 한다.
 
 **ACCESS_CONTROL_FILE**\ 의 형식은 다음과 같다.
 
@@ -1488,13 +1488,13 @@ ip_list_file의 작성 형식은 다음과 같다.
 
 *   <ip_addr>: 접근을 허용할 IP 명. 뒷자리를 \*로 입력하면 뒷자리의 모든 IP를 허용한다.
 
-**ACCESS_CONTROL** 값이 ON 상태에서 **ACCESS_CONTROL_FILE**\에 지정되지 않으면 브로커는 localhost에서만 접속을 허용한다. 
-그러나 **ACCESS_CONTROL_FILE** 에 지정되지 않은 브로커의 경우, **ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER** 의 값을 ALLOW로 설정한 브로커들에 대해서는 모든 접속 요청을 허용한다.
+**ACCESS_CONTROL** 값이 ON인 경우에도, localhost의 접속 요청은 무조건 허용한다. (즉, ip_list_file에 localhost ip인 127.0.01를 지정해도 무시됨) 
+또한, **ACCESS_CONTROL_FILE** 에 지정되지 않은 브로커는 **ACCESS_CONTROL_DEFAULT_POLICY** 가 **ALLOW** 로 설정되면 모든 접속 요청이 허용된다.
 
 **ACCESS_CONTROL_FILE** 에 지정되지 않은 브로커 접속 제한 방식.
 
 *  localhost에서만 접속 허용. (기본)
-*  ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER를 ALLOW 로 설정하면 모든 접속 허용.
+*  ACCESS_CONTROL_DEFAULT_POLICY를 ALLOW 로 설정하면 모든 접속 허용.
 
 브로커 구동 시 **ACCESS_CONTROL_FILE** 및 ip_list_file 분석에 실패하는 경우 브로커는 구동되지 않는다. 
 
@@ -1580,17 +1580,17 @@ QUERY_EDITOR 브로커는 다음과 같은 응용의 접속 요청만을 허용�
     $ cubrid broker acl status 
     ACCESS_CONTROL=ON 
     ACCESS_CONTROL_FILE=access_file.txt 
+    ACCESS_CONTROL_DEFAULT_POLICY=ALLOW
   
     [%broker1] 
-    ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER=DENY
     demodb:dba:iplist1.txt 
            CLIENT IP LAST ACCESS TIME 
     ========================================== 
-        10.20.129.11 
+      10.20.129.11 
       10.113.153.144 2013-11-07 15:19:14 
       10.113.153.145 
       10.113.153.146 
-             10.64.* 2013-11-07 15:20:50 
+      10.64.* 2013-11-07 15:20:50 
   
     testdb:dba:iplist2.txt 
            CLIENT IP LAST ACCESS TIME 
@@ -1598,7 +1598,6 @@ QUERY_EDITOR 브로커는 다음과 같은 응용의 접속 요청만을 허용�
                    * 2013-11-08 10:10:12 
 
     [%broker2]
-    ACCESS_CONTROL_BEHAVIOR_FOR_EMPTYBROKER=ALLOW
 
 **브로커 로그**
 

--- a/ko/admin/control.rst
+++ b/ko/admin/control.rst
@@ -1454,7 +1454,7 @@ SHARD-Q는 Shard Waiting Queue를 줄인 말이다. SHARD proxy 프로세스가 
 ---------------------
 
 브로커에 접속하는 응용 클라이언트를 제한하려면 **cubrid_broker.conf**\의 **ACCESS_CONTROL** 파라미터 값을 ON으로 설정하고, **ACCESS_CONTROL_FILE** 파라미터 값에 접속을 허용하는 사용자와 데이터베이스 및 IP 목록을 작성한 파일 이름을 입력한다.
-ACCESS_CONTROL_FILE에 브로커 이름이 없으면 해당 브로커로의 모든 접속이 제한된다. 이때, **ACCESS_CONTROL_DEFAULT_POLICY** 를 설정하면 모든 접속을 허용할 수 있다.
+ACCESS_CONTROL_FILE에 해당 브로커 이름이 없는 경우 그 브로커로의 모든 접속은 **ACCESS_CONTROL_DEFAULT_POLICY** 파라미터에 의해 결정된다. 이 파라미터의 값이 DENY 인 경우 접속이 제한되며, ALLOW 인 경우 접속이 허용된다.
 **ACCESS_CONTROL** 브로커 파라미터의 기본값은 **OFF** , **ACCESS_CONTROL_DEFAULT_POLICY** 의 기본값은 **DENY** 이다.
 **ACCESS_CONTROL** , **ACCESS_CONTROL_FILE** , **ACCESS_CONTROL_DEFAULT_POLICY** 파라미터는 공통 파라미터가 지정되는 [broker] 섹션 아래에 작성해야 한다.
 

--- a/ko/admin/control.rst
+++ b/ko/admin/control.rst
@@ -1488,8 +1488,7 @@ ip_list_file의 작성 형식은 다음과 같다.
 
 *   <ip_addr>: 접근을 허용할 IP 명. 뒷자리를 \*로 입력하면 뒷자리의 모든 IP를 허용한다.
 
-**ACCESS_CONTROL** 값이 ON인 경우에도, localhost의 접속 요청은 무조건 허용한다. (즉, ip_list_file에 localhost ip인 127.0.01를 지정해도 무시됨) 
-또한, **ACCESS_CONTROL_FILE** 에 지정되지 않은 브로커는 **ACCESS_CONTROL_DEFAULT_POLICY** 가 **ALLOW** 로 설정되면 모든 접속 요청이 허용된다.
+**ACCESS_CONTROL** 값이 ON인 경우에도, localhost 의 접속은 허용된다. (즉, ip_list_file에 localhost ip인 127.0.01를 지정해도 무시됨) 
 
 **ACCESS_CONTROL_FILE** 에 지정되지 않은 브로커 접속 제한 방식.
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-234

broker 세션에 ACCESS_CONTROL_DEFAULT_POLICY 를 추가함.
ACCESS_CONTROL_DEFAULT_POLICY 를 ALLOW 로 설정하면 ACCESS_CONTROL_FILE 에 작성되지 않은 broker에 대해서 접속을 서용한다.

