### PR TITLE
[CUBRIDMAN-293] [KO][EN] Revise warning: error occurs if JNI class is registered without -j option

### DIFF
--- a/en/pl/jsp.rst
+++ b/en/pl/jsp.rst
@@ -897,7 +897,7 @@ The following is an example of invoking a native function through JNI in a CUBRI
 
 .. warning::
 
-    JNI를 호출하는 자바 저장 프로시저/함수를 **-j** 옵션 없이 등록한 후 실행 시 다음과 같은 오류를 반환한다.
+    When a java stored procedure/function included JNI code is loaded without **-j** or **--jni** option, the following error is returned during execution.
     'Library load not allowed. Please load your class by using 'loadjava' with '-jni' option'
 
     To address this issue, please consider the following:

--- a/en/pl/jsp.rst
+++ b/en/pl/jsp.rst
@@ -897,18 +897,19 @@ The following is an example of invoking a native function through JNI in a CUBRI
 
 .. warning::
 
-    Registering and executing Java stored procedures/functions that invoke JNI without the **-j** option may result in a java.lang.UnsatisfiedLinkError.
+    JNI를 호출하는 자바 저장 프로시저/함수를 **-j** 옵션 없이 등록한 후 실행 시 다음과 같은 오류를 반환한다.
+    'Library load not allowed. Please load your class by using 'loadjava' with '-jni' option'
+
     To address this issue, please consider the following:
 
     * If you are loading multiple Java class files that call System.load() for the same native library path:
        * Modify the Java class files to load the native library from only one class file.
        * Register the class that loads the native library using the **-j** option of loadjava.
-       * Restart the javasp utility.
+       * Restart the PL server. (see :ref:`cubrid-pl-server`)
 
     * If you are overwriting a previously loaded Java class file using loadjava:
-       * If the class was registered without the -j option, remove that class from the java directory at the respective database path.
        * Re-register the class using the -j option with loadjava.
-       * Restart the javasp utility.
+       * Restart the pl utility. (see :ref:`cubrid-pl-server`)
 
 .. _jsp-load-java:
 

--- a/ko/pl/jsp.rst
+++ b/ko/pl/jsp.rst
@@ -881,18 +881,19 @@ CUBRID의 Java SP에서는 JNI 기능을 사용할 수 있도록 제공하고 �
 
 .. warning::
 
-    JNI를 호출하는 자바 저장 프로시저/함수를 **-j** 옵션 없이 등록한 후 실행 시 java.lang.UnsatisfiedLinkError가 발생할 수 있다.
+    JNI를 호출하는 자바 저장 프로시저/함수를 **-j** 옵션 없이 등록한 후 실행 시 다음과 같은 오류를 반환한다.
+    'Library load not allowed. Please load your class by using 'loadjava' with '-jni' option'
+
     다음의 사항을 확인한다.
 
     * 동일한 네이티브 라이브러리 경로에 대해 System.load () 를 호출하는 자바 클래스 파일을 여러 개 로드하는 경우
        * 하나의 자바 클래스 파일만 네이티브 라이브러리를 로드하도록 수정한다
        * 네이티브 라이브러리를 로드하는 클래스를 loadjava의 **-j** 옵션을 사용하여 등록한다
-       * javasp 유틸리티를 재시작한다
+       * PL 서버를 재시작한다 (:ref:`cubrid-pl-server` 참고)
 
     * 이미 로드된 자바 클래스 파일을 loadjava로 다시 덮어쓰는 경우
-       * **-j** 옵션 없이 loadjava로 클래스를 등록한 경우 해당 데이터베이스 경로의 **java** 디렉토리에서 해당 클래스를 제거한다
        * **-j** 옵션을 사용하여 loadjava로 해당 클래스를 다시 등록한다
-       * javasp 유틸리티를 재시작한다
+       * PL 서버를 재시작한다 (:ref:`cubrid-pl-server` 참고)
 
 .. _jsp-load-java:
 

--- a/ko/pl/jsp.rst
+++ b/ko/pl/jsp.rst
@@ -881,7 +881,7 @@ CUBRID의 Java SP에서는 JNI 기능을 사용할 수 있도록 제공하고 �
 
 .. warning::
 
-    JNI를 호출하는 자바 저장 프로시저/함수를 **-j** 옵션 없이 등록한 후 실행 시 다음과 같은 오류를 반환한다.
+    JNI를 호출하는 자바 저장 프로시저/함수를 **-j** 또는 **--jni** 옵션 없이 등록한 후 실행 시 다음과 같은 오류를 반환한다.
     'Library load not allowed. Please load your class by using 'loadjava' with '-jni' option'
 
     다음의 사항을 확인한다.


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-293