### PR TITLE
[CUBRIDMAN-302] add a PORT argument for livehtml in Makefile

### DIFF
--- a/en/Makefile
+++ b/en/Makefile
@@ -7,6 +7,7 @@ SPHINXBUILD   = sphinx-build
 SPHINXAUTOBUILD   = sphinx-autobuild
 PAPER         =
 BUILDDIR      = _build
+PORT          = 9000
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -49,7 +50,7 @@ html:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 livehtml:
-	$(SPHINXAUTOBUILD) --host=0.0.0.0 $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXAUTOBUILD) --host=0.0.0.0 --port=$(PORT) $(ALLSPHINXOPTS) $(BUILDDIR)/html
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/ko/Makefile
+++ b/ko/Makefile
@@ -7,6 +7,7 @@ SPHINXBUILD   = sphinx-build
 SPHINXAUTOBUILD   = sphinx-autobuild
 PAPER         =
 BUILDDIR      = _build
+PORT          = 9001
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -49,7 +50,7 @@ html:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 livehtml:
-	$(SPHINXAUTOBUILD) --host=0.0.0.0 $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXAUTOBUILD) --host=0.0.0.0 --port=$(PORT) $(ALLSPHINXOPTS) $(BUILDDIR)/html
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-302

- Add a port argument for livehtml command
- Set the default ports to 9000 and 9001 for the English and Korean manuals, respectively.