### PR TITLE
[CUBRIDMAN-161] state that DBLink cannot be used in Static SQL DML

### DIFF
--- a/en/pl/plcsql_overview.rst
+++ b/en/pl/plcsql_overview.rst
@@ -195,7 +195,7 @@ However, these must not have the `BOOLEAN` or `SYS_REFCURSOR` type,
 as they are not included in :ref:`SQL Data Types <datatype_index>`.
 
 For Static SQL, the :ref:`DBLink <dblink-introduction>` feature is supported for SELECT statements,
-but it is not yet supported for DML statements (INSERT, UPDATE, DELETE, MERGE, REPLACE).
+but it is not supported for DML statements (INSERT, UPDATE, DELETE, MERGE, REPLACE).
 To use the DBLink feature inside DML statements, you have to use Dynamic SQL described below.
 
 .. code-block:: sql

--- a/en/pl/plcsql_overview.rst
+++ b/en/pl/plcsql_overview.rst
@@ -194,6 +194,25 @@ variables, constants, and procedure/function parameters declared in PL/CSQL can 
 However, these must not have the `BOOLEAN` or `SYS_REFCURSOR` type,
 as they are not included in :ref:`SQL Data Types <datatype_index>`.
 
+For Static SQL, the :ref:`DBLink <dblink-introduction>` feature is supported for SELECT statements,
+but it is not yet supported for DML statements (INSERT, UPDATE, DELETE, MERGE, REPLACE).
+To use the DBLink feature inside DML statements, you have to use Dynamic SQL described below.
+
+.. code-block:: sql
+
+    CREATE OR REPLACE PROCEDURE test_dblink_in_dml
+    AS
+    BEGIN
+        INSERT INTO athlete@remote_svr(name, gender, nation_code, event)
+        VALUES ('Park Taehwan', 'M', 'KOR', 'Swimming');
+    END;
+
+    In line 4, column 8,
+
+    ERROR: Stored procedure compile error: Semantic: before '
+           VALUES ('Park Taehwan', 'M', 'KOR', 'Swimming')'
+    DBLink DML is not yet supported for PL/CSQL Static SQL.
+
 The following is an example of using Static SQL.
 
 .. code-block:: sql

--- a/ko/pl/plcsql_overview.rst
+++ b/ko/pl/plcsql_overview.rst
@@ -181,6 +181,26 @@ PL/CSQL에서 선언한 변수, 상수, 프로시저/함수 인자를 쓸 수 �
 단, 이들은 BOOLEAN이나 SYS_REFCURSOR 타입을 가져서는 안된다. :ref:`SQL 데이터타입 <datatype_index>`\이
 이들을 포함하지 않기 때문이다.
 
+Static SQL 중에서 SELECT 문에 대해서는 :ref:`DBLink <dblink-introduction>` 기능이 지원되지만,
+DML (INSERT, UPDATE, DELETE, MERGE, REPLACE) 문에 대해서는 아직 지원되지 않는다.
+DML 안에서 DBLink 기능을 쓰려면 아래에서 설명하는 Dynamic SQL을 사용해야 한다.
+
+.. code-block:: sql
+
+    CREATE OR REPLACE PROCEDURE test_dblink_in_dml
+    AS
+    BEGIN
+        INSERT INTO athlete@remote_svr(name, gender, nation_code, event)
+        VALUES ('Park Taehwan', 'M', 'KOR', 'Swimming');
+    END;
+
+    In line 4, column 8,
+
+    ERROR: Stored procedure compile error: Semantic: before '
+           VALUES ('Park Taehwan', 'M', 'KOR', 'Swimming')'
+    DBLink DML is not yet supported for PL/CSQL Static SQL.
+
+
 다음은 Static SQL 사용 예이다.
 
 .. code-block:: sql

--- a/ko/pl/plcsql_overview.rst
+++ b/ko/pl/plcsql_overview.rst
@@ -183,7 +183,7 @@ PL/CSQL에서 선언한 변수, 상수, 프로시저/함수 인자를 쓸 수 �
 
 Static SQL 중에서 SELECT 문에 대해서는 :ref:`DBLink <dblink-introduction>` 기능이 지원되지만,
 DML (INSERT, UPDATE, DELETE, MERGE, REPLACE) 문에 대해서는 지원되지 않는다.
-DML 안에서 DBLink 기능을 쓰려면 아래에서 설명하는 Dynamic SQL을 사용해야 한다.
+DML 문장에서 DBLink 기능을 사용하려면, 아래에서 설명하는 Dynamic SQL 을 사용해야 한다.
 
 .. code-block:: sql
 

--- a/ko/pl/plcsql_overview.rst
+++ b/ko/pl/plcsql_overview.rst
@@ -182,7 +182,7 @@ PL/CSQL에서 선언한 변수, 상수, 프로시저/함수 인자를 쓸 수 �
 이들을 포함하지 않기 때문이다.
 
 Static SQL 중에서 SELECT 문에 대해서는 :ref:`DBLink <dblink-introduction>` 기능이 지원되지만,
-DML (INSERT, UPDATE, DELETE, MERGE, REPLACE) 문에 대해서는 아직 지원되지 않는다.
+DML (INSERT, UPDATE, DELETE, MERGE, REPLACE) 문에 대해서는 지원되지 않는다.
 DML 안에서 DBLink 기능을 쓰려면 아래에서 설명하는 Dynamic SQL을 사용해야 한다.
 
 .. code-block:: sql


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26042

PL/CSQL Static SQL 중에서 DML 문에 대해서는 DBLink 기능이 아직 지원되지 않는다는 내용을 추가하였습니다. 

렌더링된 문서는 이슈 댓글에 게시된 주소에서 확인하실 수 있습니다. 
