### PR TITLE
[CUBRIDMAN-324] add links to linkcheck_ignore for unstable link

### DIFF
--- a/en/conf.py
+++ b/en/conf.py
@@ -122,7 +122,9 @@ linkcheck_ignore = [
     r'https://linux.die.net/man/2/posix_fadvise',
     r"https://dev\.mysql\.com/downloads/repo/yum/",
     r"https://dev\.mysql\.com/doc/connector-odbc/en/connector-odbc-installation-binary-yum\.html",
-    r"https://dev\.mysql\.com/doc/connector-odbc/en/connector-odbc-configuration-connection-parameters\.html#codbc-dsn-option-flags"
+    r"https://dev\.mysql\.com/doc/connector-odbc/en/connector-odbc-configuration-connection-parameters\.html#codbc-dsn-option-flags",
+    r"https://metacpan.org/dist/DBI/",
+    r"https://www\.gnu\.org/software/libc/manual/html_node/Malloc-Tunable-Parameters",
 ]
 linkcheck_timeout = 30
 linkcheck_workers = 10

--- a/ko/conf.py
+++ b/ko/conf.py
@@ -122,7 +122,9 @@ linkcheck_ignore = [
     r'https://linux.die.net/man/2/posix_fadvise',
     r"https://dev\.mysql\.com/downloads/repo/yum/",
     r"https://dev\.mysql\.com/doc/connector-odbc/en/connector-odbc-installation-binary-yum\.html",
-    r"https://dev\.mysql\.com/doc/connector-odbc/en/connector-odbc-configuration-connection-parameters\.html#codbc-dsn-option-flags"
+    r"https://dev\.mysql\.com/doc/connector-odbc/en/connector-odbc-configuration-connection-parameters\.html#codbc-dsn-option-flags",
+    r"https://metacpan.org/dist/DBI/",
+    r"https://www\.gnu\.org/software/libc/manual/html_node/Malloc-Tunable-Parameters",
 ]
 linkcheck_timeout = 30
 linkcheck_workers = 10


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-324

**Description**
CI에서 make linkcheck 시, 불안정한 link가 존재하여 이를 linkcheck_ignore 리스트에 추가합니다.
- https://metacpan.org/dist/DBI/ -> 가끔 실패
- https://www.gnu.org/software/libc/manual/html_node/Malloc-Tunable-Parameters -> 가끔 실패(봇 트래픽을 'rate limited' 처리)

실패 문구는 jira에서 확인하실 수 있습니다.