### PR TITLE
[CUBRIDMAN-326] add omitted procedure_properties and function_properties to syntax

### DIFF
--- a/en/pl/plcsql_overview.rst
+++ b/en/pl/plcsql_overview.rst
@@ -16,16 +16,16 @@ writing PL/CSQL code after the AS (or IS) keyword in the CREATE PROCEDURE or CRE
 
     <create_procedure> ::=
         CREATE [ OR REPLACE ] PROCEDURE [schema_name.]<identifier> [ ( <seq_of_parameters> ) ]
-        { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
+        [ <procedure_properties> ] { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
     <create_function> ::=
         CREATE [ OR REPLACE ] FUNCTION [schema_name.]<identifier> [ ( <seq_of_parameters> ) ] RETURN <type_spec>
-        { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
+        [ <procedure_properties> ] { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
 
 In the above syntax, the *body* of a stored procedure/function contains PL/CSQL statements.
 The declaration section, *seq_of_declare_specs*, declares variables, constants, exceptions, etc.,
 that will be used within the execution statements.
-For more details on these syntax elements, refer to :doc:`Declarations <plcsql_decl>` and
-:doc:`Statements <plcsql_stmt>`.
+For more details on these syntax elements, refer to :ref:`CREATE PROCEDURE <create-procedure>`, :ref:`CREATE FUNCTION <create-function>`,
+:doc:`Declarations <plcsql_decl>` and :doc:`Statements <plcsql_stmt>`.
 
 Stored procedures/functions are always executed with auto-commit disabled.
 This applies even if the auto-commit feature is enabled in the calling session.

--- a/en/pl/plcsql_overview.rst
+++ b/en/pl/plcsql_overview.rst
@@ -19,7 +19,7 @@ writing PL/CSQL code after the AS (or IS) keyword in the CREATE PROCEDURE or CRE
         [ <procedure_properties> ] { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
     <create_function> ::=
         CREATE [ OR REPLACE ] FUNCTION [schema_name.]<identifier> [ ( <seq_of_parameters> ) ] RETURN <type_spec>
-        [ <procedure_properties> ] { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
+        [ <function_properties> ] { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
 
 In the above syntax, the *body* of a stored procedure/function contains PL/CSQL statements.
 The declaration section, *seq_of_declare_specs*, declares variables, constants, exceptions, etc.,

--- a/en/sql/schema/stored_routine_stmt.rst
+++ b/en/sql/schema/stored_routine_stmt.rst
@@ -25,8 +25,8 @@ Create stored procedure using the **CREATE PROCEDURE** statement.
         <parameter_definition> ::= parameter_name [mode] sql_type [ { DEFAULT | = } <default_expr> ] [COMMENT 'parameter_comment_string']
         <lang> ::= [PLCSQL | JAVA]
         <mode> ::= IN | OUT | IN OUT | INOUT
-        <procedure_properties> ::= 
-          <authid> = AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
+        <procedure_properties> ::= <authid>
+            <authid> ::= AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
 
 You can use the **OR REPLACE** clause to replace or create a new stored function/procedure.
 
@@ -122,9 +122,9 @@ Create stored function using the **CREATE FUNCTION** statement.
     
         <parameter_definition> ::= parameter_name [mode] sql_type [<default_arg>] [COMMENT 'param_comment_string']
             <default_arg> ::= { DEFAULT | = } <default_expr>
-        <procedure_properties> ::= <authid> | <deterministic>
-            <authid> = AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
-            <deterministic> = [NOT DETERMINISTIC | DETERMINISTIC]
+        <function_properties> ::= [<authid>] [<deterministic>]
+            <authid> ::= AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
+            <deterministic> ::= [NOT DETERMINISTIC | DETERMINISTIC]
         <lang> ::= [PLCSQL | JAVA]
         <mode> ::= IN | OUT | IN OUT | INOUT
 

--- a/ko/pl/plcsql_overview.rst
+++ b/ko/pl/plcsql_overview.rst
@@ -16,14 +16,14 @@ PL/CSQL은 저장 프로시저나 저장 함수를 생성하는데 사용된다.
 
     <create_procedure> ::=
         CREATE [ OR REPLACE ] PROCEDURE [schema_name.]<identifier> [ ( <seq_of_parameters> ) ]
-        { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
+        [ <procedure_properties> ] { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
     <create_function> ::=
         CREATE [ OR REPLACE ] FUNCTION [schema_name.]<identifier> [ ( <seq_of_parameters> ) ] RETURN <type_spec>
-        { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
+        [ <function_properties> ] { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
 
 위 문법에서 저장 프로시저/함수의 *body*\는 PL/CSQL 실행문들을 포함하고
 그 앞의 선언부 *seq_of_declare_specs*\는 실행문들 안에서 사용될 변수, 상수, Exception 등을 선언한다.
-이들 문법 요소에 대한 자세한 내용은 :doc:`선언문 <plcsql_decl>`\과 :doc:`실행문 <plcsql_stmt>` 절을 참고한다.
+이들 문법 요소에 대한 자세한 내용은 :ref:`CREATE PROCEDURE <create-procedure>`, :ref:`CREATE FUNCTION <create-function>`, :doc:`선언문 <plcsql_decl>`, :doc:`실행문 <plcsql_stmt>` 절을 참고한다.
 
 저장 프로시저/함수는 Auto Commit 기능이 언제나 비활성화 된 상태로 실행된다.
 이는 호출한 세션에서 Auto Commit 기능이 활성화 되어 있어도 마찬가지이다.

--- a/ko/sql/schema/stored_routine_stmt.rst
+++ b/ko/sql/schema/stored_routine_stmt.rst
@@ -25,8 +25,8 @@ CREATE PROCEDURE
         <parameter_definition> ::= parameter_name [mode] sql_type [ { DEFAULT | = } <default_expr> ] [COMMENT 'parameter_comment_string']
         <lang> ::= [PLCSQL | JAVA]
         <mode> ::= IN | OUT | IN OUT | INOUT
-        <procedure_properties> ::= 
-          <authid> = AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
+        <procedure_properties> ::= <authid>
+            <authid> ::= AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
 
 **OR REPLACE** 구문을 사용하여 현재의 저장 함수/프로시저를 대체 혹은 새로 생성하는 문장을 작성할 수 있다.
 
@@ -122,9 +122,9 @@ CREATE FUNCTION
     
         <parameter_definition> ::= parameter_name [mode] sql_type [<default_arg>] [COMMENT 'param_comment_string']
             <default_arg> ::= { DEFAULT | = } <default_expr>
-        <procedure_properties> ::= <authid> | <deterministic>
-            <authid> = AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
-            <deterministic> = [NOT DETERMINISTIC | DETERMINISTIC]
+        <function_properties> ::= [<authid>] [<deterministic>]
+            <authid> ::= AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
+            <deterministic> ::= [NOT DETERMINISTIC | DETERMINISTIC]
         <lang> ::= [PLCSQL | JAVA]
         <mode> ::= IN | OUT | IN OUT | INOUT
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-326

PL/CSQL 개요 절에서 
CREATE PROCEDURE/FUNCTION의 문법에 procedure_properties와 function_properties 가 누락되어 추가합니다.
관련해서 참조할 문서에 문법 규약에 어긋난 부분들이 있는 부분도 수정했습니다. 
