### PR TITLE
[CUBRIDMAN-327] Add manual for partitioning key expression constraints and missing descriptions

### DIFF
--- a/en/sql/function/datetime_fn.rst
+++ b/en/sql/function/datetime_fn.rst
@@ -2208,6 +2208,25 @@ UTC_TIME
     ==============
       10:35:52 AM
 
+UTC_TIMESTAMP
+=============
+
+.. function:: UTC_TIMESTAMP ()
+
+    The **UTC_TIMESTAMP** function returns the UTC date and time in 'YYYY-MM-DD HH:MI:SS' format.
+
+    :rtype: STRING
+
+.. code-block:: sql
+
+    SELECT UTC_TIMESTAMP();
+    
+::
+
+      utc_timestamp()
+    ===========================
+      06:04:19 AM 12/23/2025
+
 WEEK
 ====
 

--- a/en/sql/partition.rst
+++ b/en/sql/partition.rst
@@ -21,7 +21,11 @@ The partitioning key is an expression which is used by the partitioning method t
 *   **DATE**
 *   **TIME**
 *   **TIMESTAMP**
+*   **TIMESTAMPTZ**
+*   **TIMESTAMPLTZ**
 *   **DATETIME**
+*   **DATETIMETZ**
+*   **DATETIMELTZ**
 
 The following restrictions apply to the partitioning key:
 
@@ -52,6 +56,33 @@ The following restrictions apply to the partitioning key:
     *   :c:macro:`USER` 
     *   :ref:`PRIOR <prior-operator>` 
     *   :func:`WIDTH_BUCKET`
+    *   :c:macro:`SYS_DATE`
+    *   :c:macro:`SYSDATE`
+    *   :c:macro:`SYS_TIME`
+    *   :c:macro:`SYSTIME`
+    *   :c:macro:`SYS_DATETIME`
+    *   :c:macro:`SYSDATETIME`
+    *   :c:macro:`SYS_TIMESTAMP`
+    *   :c:macro:`SYSTIMESTAMP`
+    *   :func:`CURDATE`
+    *   :func:`CURRENT_DATE`
+    *   :c:macro:`CURRENT_DATE`
+    *   :func:`CURTIME`
+    *   :func:`CURRENT_TIME`
+    *   :c:macro:`CURRENT_TIME`
+    *   :c:macro:`CURRENT_TIMESTAMP`
+    *   :func:`CURRENT_TIMESTAMP`
+    *   :c:macro:`LOCALTIME`
+    *   :func:`LOCALTIME`
+    *   :c:macro:`LOCALTIMESTAMP`
+    *   :func:`LOCALTIMESTAMP`
+    *   :func:`CURRENT_DATETIME`
+    *   :c:macro:`CURRENT_DATETIME`
+    *   :func:`NOW`
+    *   :func:`UTC_TIME`
+    *   :func:`UTC_DATE`
+    *   :func:`UTC_TIMESTAMP`
+    *   :func:`TZ_OFFSET`
 *	The partitioning key needs to be present in the key of each unique index (including primary keys). For more information on this aspect, please see :ref:`here<index-partitions>`.
 *	The partitioning expression's length must not exceed 1024 bytes.
 

--- a/ko/sql/function/datetime_fn.rst
+++ b/ko/sql/function/datetime_fn.rst
@@ -2208,6 +2208,25 @@ UTC_TIME
     ==============
       10:35:52 AM
 
+UTC_TIMESTAMP
+=============
+
+.. function:: UTC_TIMESTAMP ()
+
+    **UTC_TIMESTAMP** 함수는 UTC 날짜와 시간을 'YYYY-MM-DD HH:MI:SS' 형태로 반환한다.
+
+    :rtype: STRING
+
+.. code-block:: sql
+
+    SELECT UTC_TIMESTAMP();
+    
+::
+
+      utc_timestamp()
+    ===========================
+      06:04:19 AM 12/23/2025
+
 WEEK
 ====
 

--- a/ko/sql/partition.rst
+++ b/ko/sql/partition.rst
@@ -22,7 +22,11 @@
 *   **DATE**
 *   **TIME**
 *   **TIMESTAMP**
+*   **TIMESTAMPTZ**
+*   **TIMESTAMPLTZ**
 *   **DATETIME**
+*   **DATETIMETZ**
+*   **DATETIMELTZ**
 
 분할 키에는 다음과 같은 제약 사항이 적용된다.
 
@@ -53,6 +57,33 @@
     *   :c:macro:`USER` 
     *   :ref:`PRIOR <prior-operator>` 
     *   :func:`WIDTH_BUCKET`
+    *   :c:macro:`SYS_DATE`
+    *   :c:macro:`SYSDATE`
+    *   :c:macro:`SYS_TIME`
+    *   :c:macro:`SYSTIME`
+    *   :c:macro:`SYS_DATETIME`
+    *   :c:macro:`SYSDATETIME`
+    *   :c:macro:`SYS_TIMESTAMP`
+    *   :c:macro:`SYSTIMESTAMP`
+    *   :func:`CURDATE`
+    *   :func:`CURRENT_DATE`
+    *   :c:macro:`CURRENT_DATE`
+    *   :func:`CURTIME`
+    *   :func:`CURRENT_TIME`
+    *   :c:macro:`CURRENT_TIME`
+    *   :c:macro:`CURRENT_TIMESTAMP`
+    *   :func:`CURRENT_TIMESTAMP`
+    *   :c:macro:`LOCALTIME`
+    *   :func:`LOCALTIME`
+    *   :c:macro:`LOCALTIMESTAMP`
+    *   :func:`LOCALTIMESTAMP`
+    *   :func:`CURRENT_DATETIME`
+    *   :c:macro:`CURRENT_DATETIME`
+    *   :func:`NOW`
+    *   :func:`UTC_TIME`
+    *   :func:`UTC_DATE`
+    *   :func:`UTC_TIMESTAMP`
+    *   :func:`TZ_OFFSET`
 *       각각의 고유 인덱스 키 또는  기본 키는 분할 키를 포함해야 한다.  이에 대한 자세한 내용은 :ref:`여기<index-partitions>` 를 참고한다.
 *       분할 표현식의 길이는 1024바이트를 초과하면 안 된다.
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-327

분할 키로 사용할 수 있는 컬럼의 데이터 타입 목록에 누락된 타입을 추가합니다.

파티션 테이블에 행을 삽입할 때 오류가 발생하는 함수들을 분할 키 표현식에서 사용할 수 없다는 제약 사항을 추가합니다.
* `SYS_DATE`, `SYSDATE`
* `SYS_TIME`, `SYSTIME`
* `SYS_DATETIME`, `SYSDATETIME`
* `SYS_TIMESTAMP`, `SYSTIMESTAMP`
* `CURDATE()`, `CURRENT_DATE()`, `CURRENT_DATE`
* `CURTIME()`, `CURRENT_TIME()`, `CURRENT_TIME`
* `CURRENT_TIMESTAMP`, `CURRENT_TIMESTAMP()`, `LOCALTIME`, `LOCALTIME()`, `LOCALTIMESTAMP`, `LOCALTIMESTAMP()`
* `CURRENT_DATETIME`, `CURRENT_DATETIME()`, `NOW()`
* `UTC_TIME()`
* `UTC_DATE()`
* `UTC_TIMESTAMP()`
* `TZ_OFFSET()`

분할 키로 사용 시 문제가 발생하는 함수 중 하나인 UTC_TIMESTAMP() 함수의 설명이 누락되어 있어 추가합니다.