### PR TITLE
[CUBRIDMAN-326] add omitted procedure_properties and function_properties to syntax

### DIFF
--- a/en/pl/plcsql_decl.rst
+++ b/en/pl/plcsql_decl.rst
@@ -8,7 +8,7 @@ Each declared item can be referenced within the *body* that follows the declarat
 
 ::
 
-    <seq_of_declare_specs> ::= <declare_spec> [ <declare_spec> ... ]
+    <seq_of_declare_specs> ::= <declare_spec> { <declare_spec> }... 
     <declare_spec> ::=
           <variable_decl>
         | <constant_decl>
@@ -195,7 +195,7 @@ Cursor Declarations
     <cursor_decl> ::=
         CURSOR <identifier> [ ( <seq_of_cursor_parameters> ) ] IS <select_statement> ;
 
-    <seq_of_cursor_parameters> ::= <cursor_parameter> [, <cursor_parameter>, ...]
+    <seq_of_cursor_parameters> ::= <cursor_parameter> { , <cursor_parameter> }...
     <cursor_parameter> ::= <identifier> [ IN ] <type_spec>
     <type_spec> ::=
           <builtin_type>
@@ -266,7 +266,7 @@ modularizing it as a local procedure/function improves code readability and reus
     <inner_function_decl> ::=
         FUNCTION <identifier> [ ( <seq_of_parameters> ) ] RETURN <type_spec> { IS | AS } [ <seq_of_declare_specs> ] <body> ;
 
-    <seq_of_parameters> ::= [ <parameter> [, <parameter> ...] ]
+    <seq_of_parameters> ::= [ <parameter> { , <parameter> }... ]
     <parameter> ::= <identifier> [ { IN | IN OUT | INOUT | OUT } ] <type_spec> [ COMMENT 'param_comment_string' ]
     <type_spec> ::=
           <builtin_type>
@@ -275,10 +275,10 @@ modularizing it as a local procedure/function improves code readability and reus
         | <table>%ROWTYPE
         | <cursor>%ROWTYPE
     <body> ::= BEGIN <seq_of_statements> [ EXCEPTION <seq_of_handlers> ] END [ <label_name> ]
-    <seq_of_declare_specs> ::= <declare_spec> [ <declare_spec> ... ]
-    <seq_of_statements> ::= <statement> ; [ <statement> ; ... ]
-    <seq_of_handlers> ::= <handler> [ <handler> ... ]
-    <handler> ::= WHEN <exception_name> [ OR <exception_name> OR ... ] THEN <seq_of_statements>
+    <seq_of_declare_specs> ::= <declare_spec> { <declare_spec> }...
+    <seq_of_statements> ::= <statement> ; { <statement> ; }... 
+    <seq_of_handlers> ::= <handler> { <handler> }... 
+    <handler> ::= WHEN <exception_name> { OR <exception_name> }...  THEN <seq_of_statements>
     <exception_name> ::= identifier | OTHERS
 
 * *parameter*: parameters can be declared as IN, IN OUT, INOUT, or OUT. IN OUT and INOUT are equivalent.

--- a/en/pl/plcsql_overview.rst
+++ b/en/pl/plcsql_overview.rst
@@ -16,16 +16,16 @@ writing PL/CSQL code after the AS (or IS) keyword in the CREATE PROCEDURE or CRE
 
     <create_procedure> ::=
         CREATE [ OR REPLACE ] PROCEDURE [schema_name.]<identifier> [ ( <seq_of_parameters> ) ]
-        { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
+        [ <procedure_properties> ] { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
     <create_function> ::=
         CREATE [ OR REPLACE ] FUNCTION [schema_name.]<identifier> [ ( <seq_of_parameters> ) ] RETURN <type_spec>
-        { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
+        [ <function_properties> ] { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
 
 In the above syntax, the *body* of a stored procedure/function contains PL/CSQL statements.
 The declaration section, *seq_of_declare_specs*, declares variables, constants, exceptions, etc.,
 that will be used within the execution statements.
-For more details on these syntax elements, refer to :doc:`Declarations <plcsql_decl>` and
-:doc:`Statements <plcsql_stmt>`.
+For more details on these syntax elements, refer to :ref:`CREATE PROCEDURE <create-procedure>`, :ref:`CREATE FUNCTION <create-function>`,
+:doc:`Declarations <plcsql_decl>` and :doc:`Statements <plcsql_stmt>`.
 
 Stored procedures/functions are always executed with auto-commit disabled.
 This applies even if the auto-commit feature is enabled in the calling session.

--- a/en/pl/plcsql_stmt.rst
+++ b/en/pl/plcsql_stmt.rst
@@ -38,10 +38,10 @@ Like procedures/functions, a BLOCK can have an exception handling structure.
         [ DECLARE <seq_of_declare_specs> ] <body>
 
     <body> ::= BEGIN <seq_of_statements> [ EXCEPTION <seq_of_handlers> ] END [ <label_name> ]
-    <seq_of_declare_specs> ::= <declare_spec> [ <declare_spec> ... ]
-    <seq_of_statements> ::= <statement> ; [ <statement> ; ... ]
-    <seq_of_handlers> ::= <handler> [ <handler> ... ]
-    <handler> ::= WHEN <exception_name> [ OR <exeption_name> OR ... ] THEN <seq_of_statements>
+    <seq_of_declare_specs> ::= <declare_spec> { <declare_spec> }...
+    <seq_of_statements> ::= <statement> ; { <statement> ; }...
+    <seq_of_handlers> ::= <handler> { <handler> }...
+    <handler> ::= WHEN <exception_name> { OR <exeption_name> }... THEN <seq_of_statements>
     <exception_name> ::= identifier | OTHERS
 
 * *body*: must consist of one or more statements, optionally followed by exception handlers.
@@ -117,7 +117,7 @@ Cursor manipulation statements come in the following four forms:
         | <open_for_statement>
 
     <open_statement> ::= OPEN <cursor> [ <function_argument> ]
-    <fetch_statement> ::= FETCH <cursor_expression> INTO <identifier> [ , <identifier>, ... ]
+    <fetch_statement> ::= FETCH <cursor_expression> INTO <identifier> { , <identifier> }...
     <close_statement> ::= CLOSE <cursor_expression>
 
     <open_for_statement> ::= OPEN <identifier> FOR <select_statement>
@@ -241,9 +241,9 @@ if more than one row is returned, `TOO_MANY_ROWS` is raised.
 
     <execute_immediate> ::=
         EXECUTE IMMEDIATE <dynamic_sql> { [ <into_clause> ] [ <using_clause> ] | <using_clause> <into_clause> }
-        <using_clause> ::= USING <using_element> [ , <using_element>, ... ]
+        <using_clause> ::= USING <using_element> { , <using_element> }...
         <using_element> ::= [ IN ] <expression>
-        <into_clause> ::= INTO <identifier> [ , <identifier>, ... ]
+        <into_clause> ::= INTO <identifier> { , <identifier> }...
 
 * *dynamic_sql*: an expression of string type. It must evaluate to a syntactically valid SQL string.
   You may use `?` placeholders for values.
@@ -410,7 +410,7 @@ Procedure Call
 
     <procedure_call> ::=
         <identifier> [ <function_argument> ]
-    <function_argument> ::= ( [ <expression> [ , <expression>, ... ] ] )
+    <function_argument> ::= ( [ <expression> { , <expression> }... ] )
 
 Calls the procedure identified by *identifier*, optionally passing *function_argument* values.
 The number and types of arguments must match those declared in the procedure.
@@ -447,7 +447,7 @@ IF
 
     <if_statement> ::=
         IF <expression> THEN <seq_of_statements>
-        [ <elsif_part> [ <elsif_part> ... ] ]
+        [ <elsif_part> { <elsif_part> }... ]
         [ <else_part> ]
         END IF
     <elsif_part> ::= ELSIF <expression> THEN <seq_of_statements>

--- a/en/sql/schema/stored_routine_stmt.rst
+++ b/en/sql/schema/stored_routine_stmt.rst
@@ -25,8 +25,8 @@ Create stored procedure using the **CREATE PROCEDURE** statement.
         <parameter_definition> ::= parameter_name [mode] sql_type [ { DEFAULT | = } <default_expr> ] [COMMENT 'parameter_comment_string']
         <lang> ::= [PLCSQL | JAVA]
         <mode> ::= IN | OUT | IN OUT | INOUT
-        <procedure_properties> ::= 
-          <authid> = AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
+        <procedure_properties> ::= <authid>
+            <authid> ::= AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
 
 You can use the **OR REPLACE** clause to replace or create a new stored function/procedure.
 
@@ -122,9 +122,9 @@ Create stored function using the **CREATE FUNCTION** statement.
     
         <parameter_definition> ::= parameter_name [mode] sql_type [<default_arg>] [COMMENT 'param_comment_string']
             <default_arg> ::= { DEFAULT | = } <default_expr>
-        <procedure_properties> ::= <authid> | <deterministic>
-            <authid> = AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
-            <deterministic> = [NOT DETERMINISTIC | DETERMINISTIC]
+        <function_properties> ::= [<authid>] [<deterministic>]
+            <authid> ::= AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
+            <deterministic> ::= [NOT DETERMINISTIC | DETERMINISTIC]
         <lang> ::= [PLCSQL | JAVA]
         <mode> ::= IN | OUT | IN OUT | INOUT
 

--- a/ko/pl/plcsql_decl.rst
+++ b/ko/pl/plcsql_decl.rst
@@ -9,7 +9,7 @@
 
 ::
 
-    <seq_of_declare_specs> ::= <declare_spec> [ <declare_spec> ... ]
+    <seq_of_declare_specs> ::= <declare_spec> { <declare_spec> }...
     <declare_spec> ::=
           <variable_decl>
         | <constant_decl>
@@ -71,14 +71,14 @@
 .. code-block:: sql
 
     CREATE OR REPLACE PROCEDURE poo(a INT) AS
-    
+
         PROCEDURE inner AS
             i INT := a;
             a NUMERIC;
         BEGIN
             ...
         END;
-    
+
     BEGIN
         ...
     END;
@@ -198,7 +198,7 @@ Exception 선언
     <cursor_decl> ::=
         CURSOR <identifier> [ ( <seq_of_cursor_parameters> ) ] IS <select_statement> ;
 
-    <seq_of_cursor_parameters> ::= <cursor_parameter> [, <cursor_parameter>, ...]
+    <seq_of_cursor_parameters> ::= <cursor_parameter> { , <cursor_parameter> }...
     <cursor_parameter> ::= <identifier> [ IN ] <type_spec>
     <type_spec> ::=
           <builtin_type>
@@ -270,7 +270,7 @@ Exception 선언
     <inner_function_decl> ::=
         FUNCTION <identifier> [ ( <seq_of_parameters> ) ] RETURN <type_spec> { IS | AS } [ <seq_of_declare_specs> ] <body> ;
 
-    <seq_of_parameters> ::= [ <parameter> [, <parameter> ...] ]
+    <seq_of_parameters> ::= [ <parameter> { , <parameter> }... ]
     <parameter> ::= <identifier> [ { IN | IN OUT | INOUT | OUT } ] <type_spec> [ COMMENT 'param_comment_string' ]
     <type_spec> ::=
           <builtin_type>
@@ -279,10 +279,10 @@ Exception 선언
         | <table>%ROWTYPE
         | <cursor>%ROWTYPE
     <body> ::= BEGIN <seq_of_statements> [ EXCEPTION <seq_of_handlers> ] END [ <label_name> ]
-    <seq_of_declare_specs> ::= <declare_spec> [ <declare_spec> ... ]
-    <seq_of_statements> ::= <statement> ; [ <statement> ; ... ]
-    <seq_of_handlers> ::= <handler> [ <handler> ... ]
-    <handler> ::= WHEN <exception_name> [ OR <exeption_name> OR ... ] THEN <seq_of_statements>
+    <seq_of_declare_specs> ::= <declare_spec> { <declare_spec> }...
+    <seq_of_statements> ::= <statement> ; { <statement> ; }...
+    <seq_of_handlers> ::= <handler> { <handler> }...
+    <handler> ::= WHEN <exception_name> { OR <exeption_name> }... THEN <seq_of_statements>
     <exception_name> ::= identifier | OTHERS
 
 * *parameter*: 인자는 IN, IN OUT, INOUT, OUT 네 가지 경우로 선언할 수 있다. IN OUT과 INOUT은 동일한 효과를 갖는다.

--- a/ko/pl/plcsql_overview.rst
+++ b/ko/pl/plcsql_overview.rst
@@ -16,14 +16,14 @@ PL/CSQL은 저장 프로시저나 저장 함수를 생성하는데 사용된다.
 
     <create_procedure> ::=
         CREATE [ OR REPLACE ] PROCEDURE [schema_name.]<identifier> [ ( <seq_of_parameters> ) ]
-        { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
+        [ <procedure_properties> ] { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
     <create_function> ::=
         CREATE [ OR REPLACE ] FUNCTION [schema_name.]<identifier> [ ( <seq_of_parameters> ) ] RETURN <type_spec>
-        { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
+        [ <function_properties> ] { IS | AS } [ LANGUAGE PLCSQL ] [ <seq_of_declare_specs> ] <body> ;
 
 위 문법에서 저장 프로시저/함수의 *body*\는 PL/CSQL 실행문들을 포함하고
 그 앞의 선언부 *seq_of_declare_specs*\는 실행문들 안에서 사용될 변수, 상수, Exception 등을 선언한다.
-이들 문법 요소에 대한 자세한 내용은 :doc:`선언문 <plcsql_decl>`\과 :doc:`실행문 <plcsql_stmt>` 절을 참고한다.
+이들 문법 요소에 대한 자세한 내용은 :ref:`CREATE PROCEDURE <create-procedure>`, :ref:`CREATE FUNCTION <create-function>`, :doc:`선언문 <plcsql_decl>`, :doc:`실행문 <plcsql_stmt>` 절을 참고한다.
 
 저장 프로시저/함수는 Auto Commit 기능이 언제나 비활성화 된 상태로 실행된다.
 이는 호출한 세션에서 Auto Commit 기능이 활성화 되어 있어도 마찬가지이다.

--- a/ko/pl/plcsql_stmt.rst
+++ b/ko/pl/plcsql_stmt.rst
@@ -34,10 +34,10 @@ BLOCK은 프로시저/함수와 마찬가지로 Exception 처리 구조를 가�
         [ DECLARE <seq_of_declare_specs> ] <body>
 
     <body> ::= BEGIN <seq_of_statements> [ EXCEPTION <seq_of_handlers> ] END [ <label_name> ]
-    <seq_of_declare_specs> ::= <declare_spec> [ <declare_spec> ... ]
-    <seq_of_statements> ::= <statement> ; [ <statement> ; ... ]
-    <seq_of_handlers> ::= <handler> [ <handler> ... ]
-    <handler> ::= WHEN <exception_name> [ OR <exeption_name> OR ... ] THEN <seq_of_statements>
+    <seq_of_declare_specs> ::= <declare_spec> { <declare_spec> }...
+    <seq_of_statements> ::= <statement> ; { <statement> ; }...
+    <seq_of_handlers> ::= <handler> { <handler> }...
+    <handler> ::= WHEN <exception_name> { OR <exeption_name> }... THEN <seq_of_statements>
     <exception_name> ::= identifier | OTHERS
 
 
@@ -110,7 +110,7 @@ COMMIT, ROLLBACK, TRUNCATE 문은 프로그램의 실행문으로서 직접 사�
         | <open_for_statement>
 
     <open_statement> ::= OPEN <cursor> [ <function_argument> ]
-    <fetch_statement> ::= FETCH <cursor_expression> INTO <identifier> [ , <identifier>, ... ]
+    <fetch_statement> ::= FETCH <cursor_expression> INTO <identifier> { , <identifier> }...
     <close_statement> ::= CLOSE <cursor_expression>
 
     <open_for_statement> ::= OPEN <identifier> FOR <select_statement>
@@ -227,9 +227,9 @@ INTO 절을 포함한 경우 SELECT 문의 조회 결과는 단 한 건의 결�
 
     <execute_immediate> ::=
         EXECUTE IMMEDIATE <dynamic_sql> { [ <into_clause> ] [ <using_clause> ] | <using_clause> <into_clause> }
-        <using_clause> ::= USING <using_element> [ , <using_element>, ... ]
+        <using_clause> ::= USING <using_element> { , <using_element> }...
         <using_element> ::= [ IN ] <expression>
-        <into_clause> ::= INTO <identifier> [ , <identifier>, ... ]
+        <into_clause> ::= INTO <identifier> { , <identifier> }...
 
 
 * *dynamic_sql*: 문자열 타입을 갖는 표현식. 표현식은 SQL 규약에 맞는 SQL 구문 문자열을 계산 결과로 가져야 한다.
@@ -388,7 +388,7 @@ RETURN
 
     <procedure_call> ::=
         <identifier> [ <function_argument> ]
-    <function_argument> ::= ( [ <expression> [ , <expression>, ... ] ] )
+    <function_argument> ::= ( [ <expression> { , <expression> }... ] )
 
 이름 *identifier*\로 지정된 프로시저를 인자 *function_argument*\를 주어 호출한다.
 인자 개수와 각각의 타입은 해당 프로시저의 선언과 일치해야 한다.
@@ -422,7 +422,7 @@ IF
 ::
 
     <if_statement> ::=
-        IF <expression> THEN <seq_of_statements> [ <elsif_part> [ <elsif_part> ... ] ] [ <else_part> ] END IF
+        IF <expression> THEN <seq_of_statements> [ <elsif_part> { <elsif_part> }... ] [ <else_part> ] END IF
     <elsif_part> ::= ELSIF <expression> THEN <seq_of_statements>
     <else_part> ::= ELSE <seq_of_statements>
 

--- a/ko/sql/schema/stored_routine_stmt.rst
+++ b/ko/sql/schema/stored_routine_stmt.rst
@@ -25,8 +25,8 @@ CREATE PROCEDURE
         <parameter_definition> ::= parameter_name [mode] sql_type [ { DEFAULT | = } <default_expr> ] [COMMENT 'parameter_comment_string']
         <lang> ::= [PLCSQL | JAVA]
         <mode> ::= IN | OUT | IN OUT | INOUT
-        <procedure_properties> ::= 
-          <authid> = AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
+        <procedure_properties> ::= <authid>
+            <authid> ::= AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
 
 **OR REPLACE** 구문을 사용하여 현재의 저장 함수/프로시저를 대체 혹은 새로 생성하는 문장을 작성할 수 있다.
 
@@ -122,9 +122,9 @@ CREATE FUNCTION
     
         <parameter_definition> ::= parameter_name [mode] sql_type [<default_arg>] [COMMENT 'param_comment_string']
             <default_arg> ::= { DEFAULT | = } <default_expr>
-        <procedure_properties> ::= <authid> | <deterministic>
-            <authid> = AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
-            <deterministic> = [NOT DETERMINISTIC | DETERMINISTIC]
+        <function_properties> ::= [<authid>] [<deterministic>]
+            <authid> ::= AUTHID {DEFINER | OWNER | CALLER | CURRENT_USER}
+            <deterministic> ::= [NOT DETERMINISTIC | DETERMINISTIC]
         <lang> ::= [PLCSQL | JAVA]
         <mode> ::= IN | OUT | IN OUT | INOUT
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-326

* add omitted procedure_properties and function_properties to syntax
* fix a wrong syntax on repetitions

11.5 에 대해 수정했던 procecdure/function properties 관련 문법 요소 추가에 더하여 
큐브리드 메뉴얼의 문법 기술 방식 중 반복 관련 문법이 틀린 부분 여러 군데를 수정하였습니다. 