### PR TITLE
Revise github action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -127,12 +127,12 @@ jobs:
           name: build-artifact-${{ matrix.lang }}
           path: ./dist
 
-      # 3. Deploy Preview (PR only)
+      # Deploy Preview (PR only)
       - name: Deploy Preview
         if: github.event_name == 'pull_request'
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GH_PAGES_TOKEN }}
+          personal_token: ${{ secrets.GH_PAGES_TOKEN }}
           external_repository: ${{ github.repository_owner }}/cubrid-manual
           publish_branch: gh-pages
           publish_dir: ./dist
@@ -141,7 +141,7 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
 
-      # [4-1/4-2] Official Deploy (Push only)
+      # Official Deploy (Push only)
       - name: Deploy Official
         if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v4
@@ -165,7 +165,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: thollander/actions-comment-pull-request@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
+          github_token: ${{ secrets.GH_PAGES_TOKEN }}
           message: |
             ✅ **CUBRID Manual Preview is Ready!**
             All docs (KO/EN) are successfully built and deployed.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,9 @@ on:
 permissions:
   contents: write
   pull-requests: write
-
+  pages: write
+  id-token: write
+  
 jobs:
   # [JOB 1] Parallel Build
   build_docs:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,37 +13,189 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-# 
-name: github-checks
-on:
-  - pull_request
+#  
+name: CUBRID Manual CI/CD (Rocky Linux)
 
-# Set environment variables available to all action steps.
-env:
-  DOMAIN: cubrid-manual-${{ github.event.pull_request.number }}.surge.sh
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ "develop", "release/[0-9]*" ]
+  pull_request:
+    branches: [ "develop", "release/[0-9]*" ]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
+  # [JOB 1] Parallel Build
   build_docs:
     runs-on: ubuntu-latest
+    outputs:
+      merged_pr: ${{ steps.pr_info.outputs.merged_pr }}
     strategy:
       matrix:
         lang: [en, ko]
       fail-fast: false
+    container:
+      image: rockylinux:9.3
     steps:
-    - name: Set up Python
-      uses: actions/checkout@v1
-    - name: Build and Test Sphinx Doc
-      uses: ammaraskar/sphinx-action@7.3.1
-      with:
-        docs-folder: ${{ matrix.lang }}
-        pre-build-command: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-    - name: Check link
-      uses: ammaraskar/sphinx-action@7.3.1
-      with:
-        docs-folder: ${{ matrix.lang }}
-        pre-build-command: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        build-command: make linkcheck
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Dependencies (with Retry)
+        run: |
+          # DNF Retry Logic
+          for i in {1..3}; do
+            dnf install -y epel-release && \
+            dnf install -y glibc-locale-source glibc-langpack-ko \
+            gcc make openssl-devel bzip2-devel libffi-devel zlib-devel unzip pango cairo \
+            git gdk-pixbuf2 python3.12 python3.12-pip jq && break || sleep 5;
+          done
+          
+          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2
+          update-alternatives --set python3 /usr/bin/python3.12
+          
+          # PIP Retry Logic
+          for i in {1..3}; do
+            pip3.12 install 'urllib3<2.0' Sphinx==9.1.0 \
+            sphinx_design sphinxext-rediraffe sphinxawesome-theme==6.0.0 \
+            weasyprint==68.0 sphinx-simplepdf==1.7 sphinx-rtd-theme && break || sleep 5;
+          done
+          localedef -f UTF-8 -i ko_KR ko_KR.utf8
+
+      - name: Build Manual (HTML & PDF)
+        env:
+          LANG: ko_KR.utf8
+        run: |
+          cd ${{ matrix.lang }}
+          make html
+          make pdf
+          if [ -f "_build/simplepdf/CUBRID.pdf" ]; then
+            cp _build/simplepdf/CUBRID.pdf _build/html/CUBRID.pdf
+          fi
+
+      # Save PR number for later jobs
+      - name: Get PR number
+        if: github.event_name == 'push'
+        id: pr_info
+        run: |
+          PR_NUMBER=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            | jq -r '.[0].number')
+          echo "merged_pr=${PR_NUMBER:-manual-push}" >> $GITHUB_OUTPUT
+
+      # Temporarily store build results to share between jobs
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact-${{ matrix.lang }}
+          path: ./${{ matrix.lang }}/_build/html
+          retention-days: 1
+
+  # [JOB 2] Sequential Deployment (Fixes Race Condition)
+  deploy_docs:
+    needs: build_docs
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lang: [en, ko]
+      max-parallel: 1 # Important: Prevents "cannot lock ref" by deploying one by one
+    steps:
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact-${{ matrix.lang }}
+          path: ./dist
+
+      # 3. Deploy Preview (PR only)
+      - name: Deploy Preview
+        if: github.event_name == 'pull_request'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          destination_dir: pr-preview/${{ github.event.pull_request.number }}/${{ matrix.lang }}
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
+      # [4-1/4-2] Official Deploy (Push only)
+      - name: Deploy Official
+        if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          destination_dir: ${{ matrix.lang }}/${{ github.ref_name }}
+          keep_files: false
+          force_detach: true
+
+  # [JOB 3] Post Comments (Only when all deploys are finished)
+  comment_on_pr:
+    needs: [build_docs, deploy_docs]
+    if: success()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # Case A: Post PR Preview Link
+      - name: Comment PR Link
+        if: github.event_name == 'pull_request'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            ✅ **CUBRID Manual Preview is Ready!**
+            All docs (KO/EN) are successfully built and deployed.
+
+            | Type | 🇰🇷 Korean (KO) | 🇺🇸 English (EN) |
+            | :--- | :--- | :--- |
+            | 🌐 **Web** | [View Docs](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/ko/index.html) | [View Docs](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/en/index.html) |
+            | 📄 **PDF** | [Download](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/ko/CUBRID.pdf) | [Download](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/en/CUBRID.pdf) |
+
+            ---
+            <details>
+            <summary>🔍 <b>Page not found? (404 Error) / 페이지가 보이지 않나요?</b></summary>
+            <br />
+
+            **🇰🇷 가이드 (For @${{ github.event.pull_request.user.login }})**
+            1. [**Settings > Pages**](https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/settings/pages) 메뉴로 이동합니다.
+            2. **Branch**를 `gh-pages`로 선택하고 `/(root)`를 저장(Save)하세요.
+            3. 설정 후 이 PR의 **Actions** 탭에서 **Re-run all jobs**를 클릭하면 URL이 활성화됩니다.
+
+            **🇺🇸 Guide (For @${{ github.event.pull_request.user.login }})**
+            1. Go to your [**Settings > Pages**](https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/settings/pages).
+            2. Select `gh-pages` **Branch** and `/(root)`, then click **Save**.
+            3. After saving, go to the **Actions** tab of this PR and **Re-run all jobs** to activate the URL.
+            </details>
+          comment_tag: cubrid-manual-preview
+          mode: recreate
+          refresh_message_id: true
+      # Case B: Post Official Deployment Success (Merge only)
+      - name: Comment Official Deploy Success
+        if: github.event_name == 'push' && needs.build_docs.outputs.merged_pr != 'null'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          pr_number: ${{ needs.build_docs.outputs.merged_pr }}
+          message: |
+            🚀 **Official Deployment Complete!**
+            The changes have been merged and published to the official manual.
+
+            | Language | 🌐 Official Web Link |
+            | :--- | :--- |
+            | 🇰🇷 **Korean** | [View Official](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/ko/${{ github.ref_name }}/index.html) |
+            | 🇺🇸 **English** | [View Official](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/en/${{ github.ref_name }}/index.html) |
+          comment_tag: cubrid-manual-official-deploy
+          mode: create
+

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -108,6 +108,9 @@ jobs:
   deploy_docs:
     needs: build_docs
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-deploy-${{ github.ref }} 
+      cancel-in-progress: false               
     strategy:
       matrix:
         lang: [en, ko]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,7 +23,7 @@ concurrency:
 on:
   push:
     branches: [ "develop", "release/[0-9]*" ]
-  pull_request:
+  pull_request_target:
     branches: [ "develop", "release/[0-9]*" ]
 
 permissions:
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Cache pip
         uses: actions/cache@v4
@@ -119,7 +121,7 @@ jobs:
     strategy:
       matrix:
         lang: [en, ko]
-      max-parallel: 1 # Important: Prevents "cannot lock ref" by deploying one by one
+      max-parallel: 1
     steps:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
@@ -127,16 +129,15 @@ jobs:
           name: build-artifact-${{ matrix.lang }}
           path: ./dist
 
-      # Deploy Preview (PR only)
+      # Deploy Preview (PR only) - upstream repo의 gh-pages에 PR별 디렉토리로 배포
       - name: Deploy Preview
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.GH_PAGES_TOKEN }}
-          external_repository: ${{ github.repository_owner }}/cubrid-manual
           publish_branch: gh-pages
           publish_dir: ./dist
-          dest_dir: pr-preview/${{ env.PR_NUMBER }}
+          dest_dir: pr-preview/${{ github.event.pull_request.number }}/${{ matrix.lang }}
           keep_files: true
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
@@ -162,37 +163,39 @@ jobs:
     steps:
       # Case A: Post PR Preview Link
       - name: Comment PR Link
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: thollander/actions-comment-pull-request@v2
         with:
           github_token: ${{ secrets.GH_PAGES_TOKEN }}
+          pr_number: ${{ github.event.pull_request.number }}
           message: |
             ✅ **CUBRID Manual Preview is Ready!**
             All docs (KO/EN) are successfully built and deployed.
 
             | Type | 🇰🇷 Korean (KO) | 🇺🇸 English (EN) |
             | :--- | :--- | :--- |
-            | 🌐 **Web** | [View Docs](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/ko/index.html) | [View Docs](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/en/index.html) |
-            | 📄 **PDF** | [Download](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/ko/CUBRID.pdf) | [Download](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/en/CUBRID.pdf) |
+            | 🌐 **Web** | [View Docs](https://CUBRID.github.io/cubrid-manual/pr-preview/${{ github.event.pull_request.number }}/ko/index.html) | [View Docs](https://CUBRID.github.io/cubrid-manual/pr-preview/${{ github.event.pull_request.number }}/en/index.html) |
+            | 📄 **PDF** | [Download](https://CUBRID.github.io/cubrid-manual/pr-preview/${{ github.event.pull_request.number }}/ko/CUBRID.pdf) | [Download](https://CUBRID.github.io/cubrid-manual/pr-preview/${{ github.event.pull_request.number }}/en/CUBRID.pdf) |
 
             ---
             <details>
             <summary>🔍 <b>Page not found? (404 Error) / 페이지가 보이지 않나요?</b></summary>
             <br />
 
-            **🇰🇷 가이드 (For @${{ github.event.pull_request.user.login }})**
-            1. [**Settings > Pages**](https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/settings/pages) 메뉴로 이동합니다.
+            **🇰🇷 가이드**
+            1. [**Settings > Pages**](https://github.com/CUBRID/cubrid-manual/settings/pages) 메뉴로 이동합니다.
             2. **Branch**를 `gh-pages`로 선택하고 `/(root)`를 저장(Save)하세요.
             3. 설정 후 이 PR의 **Actions** 탭에서 **Re-run all jobs**를 클릭하면 URL이 활성화됩니다.
 
-            **🇺🇸 Guide (For @${{ github.event.pull_request.user.login }})**
-            1. Go to your [**Settings > Pages**](https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/settings/pages).
+            **🇺🇸 Guide**
+            1. Go to [**Settings > Pages**](https://github.com/CUBRID/cubrid-manual/settings/pages).
             2. Select `gh-pages` **Branch** and `/(root)`, then click **Save**.
             3. After saving, go to the **Actions** tab of this PR and **Re-run all jobs** to activate the URL.
             </details>
           comment_tag: cubrid-manual-preview
           mode: recreate
           refresh_message_id: true
+
       # Case B: Post Official Deployment Success (Merge only)
       - name: Comment Official Deploy Success
         if: github.event_name == 'push' && needs.build_docs.outputs.merged_pr != 'null'
@@ -205,8 +208,7 @@ jobs:
 
             | Language | 🌐 Official Web Link |
             | :--- | :--- |
-            | 🇰🇷 **Korean** | [View Official](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/ko/${{ github.ref_name }}/index.html) |
-            | 🇺🇸 **English** | [View Official](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/en/${{ github.ref_name }}/index.html) |
+            | 🇰🇷 **Korean** | [View Official](https://CUBRID.github.io/cubrid-manual/ko/${{ github.ref_name }}/index.html) |
+            | 🇺🇸 **English** | [View Official](https://CUBRID.github.io/cubrid-manual/en/${{ github.ref_name }}/index.html) |
           comment_tag: cubrid-manual-official-deploy
           mode: create
-

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -110,6 +110,9 @@ jobs:
   deploy_docs:
     needs: build_docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     concurrency:
       group: gh-pages-deploy-${{ github.ref }} 
       cancel-in-progress: false               

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -132,9 +132,11 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_PAGES_TOKEN }}
+          external_repository: ${{ github.repository_owner }}/cubrid-manual
+          publish_branch: gh-pages
           publish_dir: ./dist
-          destination_dir: pr-preview/${{ github.event.pull_request.number }}/${{ matrix.lang }}
+          dest_dir: pr-preview/${{ env.PR_NUMBER }}
           keep_files: true
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
@@ -163,6 +165,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: thollander/actions-comment-pull-request@v2
         with:
+          GITHUB_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
           message: |
             ✅ **CUBRID Manual Preview is Ready!**
             All docs (KO/EN) are successfully built and deployed.

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,50 @@
+name: Cleanup PR Preview
+
+on:
+  pull_request:
+    types: [closed] # Execute immediately when a PR is merged or closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push deletion commits to the gh-pages branch
+
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages # Checkout the branch where preview data is stored
+
+      - name: Delete PR Preview Folder
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          TARGET_DIR="pr-preview/$PR_NUMBER"
+          
+          echo "Target PR Number: $PR_NUMBER"
+          
+          # Check if the directory for the specific PR exists
+          if [ -d "$TARGET_DIR" ]; then
+            echo "Folder $TARGET_DIR found. Starting cleanup..."
+            
+            # Remove the directory
+            rm -rf "$TARGET_DIR"
+            
+            # Git configuration (using GitHub Actions Bot account)
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            
+            # Stage changes
+            git add .
+            
+            # Check for changes, then commit and push if necessary
+            if ! git diff --cached --quiet; then
+              git commit -m "Cleanup: Remove preview for PR #$PR_NUMBER"
+              git push origin gh-pages
+              echo "✅ Successfully cleaned up PR #$PR_NUMBER preview from gh-pages."
+            else
+              echo "⚠️ No changes to commit (already clean)."
+            fi
+          else
+            echo "ℹ️ No preview folder exists for PR #$PR_NUMBER. Nothing to do."
+          fi

--- a/.github/workflows/daily-archive-cleanup.yml
+++ b/.github/workflows/daily-archive-cleanup.yml
@@ -1,0 +1,51 @@
+name: Daily Build Cleanup
+
+on:
+  schedule:
+    # Run at 03:00 KST (18:00 UTC) every day
+    - cron: '0 18 * * *'
+  workflow_dispatch: # Allows manual execution by administrators
+
+jobs:
+  purge-old-builds:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Delete builds older than 30 days
+        run: |
+          echo "Starting cleanup for builds older than 30 days..."
+          
+          # 1. Clean up temporary PR preview folders (pr-preview/*)
+          if [ -d "pr-preview" ]; then
+            # Find and delete all PR number folders under pr-preview that are older than 30 days
+            find pr-preview/* -maxdepth 0 -type d -mtime +30 -exec rm -rf {} \;
+            echo "Cleaned up old pr-preview folders."
+          fi
+
+          # 2. Clean up archived PR folders in official paths (e.g., ko/develop/PR-*)
+          # Target all directories starting with 'PR-' under any language/branch path
+          echo "Searching for archived PR folders in official paths..."
+          find . -type d -name "PR-*" -mtime +30 -exec rm -rf {} \;
+          
+          # Git configuration for automated commits
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Stage deletion changes
+          git add .
+          
+          # Check for changes and push if there is anything to commit
+          if ! git diff --cached --quiet; then
+            git commit -m "Cleanup: Purge archived PR builds older than 30 days"
+            git push origin gh-pages
+            echo "✅ Successfully pushed cleanup changes."
+          else
+            echo "ℹ️ No old builds found to delete. Everything is clean."
+          fi


### PR DESCRIPTION
관련해서 이전 PR #743 은 revert 되었고 
추가 수정 사항을 포함합니다. 
다시 리뷰 부탁드립니다. 

**기존** 
-   en, ko 각각 빌드 성공 여부만 확인 

**변경**
-   check.yml
     PR 브랜치 빌드 결과 생성된 파일(html, pdf) 링크를 PR 화면 해당 commit 다음에 코멘트
     머지 완료 후  빌드 및 링크를 PR 화면 하단에 코멘트 

-   cleanup.yml
     PR 에서 저장된 파일 (html, pdf)을 머지, close 시 삭제

-   daily-archive-cleanup.yml
    30일 이후 결과물 제거


**동작 예**
- PR open  시  파일(html, pdf) 링크 정보 comment 됨. 
<img width="558" height="690" alt="image" src="https://github.com/user-attachments/assets/1abd8c5a-8f48-484c-887d-460b1a41ad4a" />

- commit 시 파일(html, pdf) 링크 정보 comment 됨. 이전 comment 는 지워짐. 
  즉, 최근 commit 에 대한 정보만 comment 표시.  
<img width="498" height="527" alt="image" src="https://github.com/user-attachments/assets/309d0174-8a25-4b26-9758-5807680e01ee" />

- 머지하면 마지막 commit 의 파일(html, pdf) 을 삭제함. 
- 머지된 브랜치를 빌드하고 생성된 파일(html, pdf) 링크 정보를 PR 화면 하단에 표시   
<img width="750" height="358" alt="image" src="https://github.com/user-attachments/assets/e214f625-542a-4491-9602-618f65899650" />

- 생성된지 30일 이상된 파일은 한국 시간 새벽 3시에 github action 이 자동 삭제. 

