### PR TITLE
[CUBRIDMAN-332] Add a publishing function on PR screen

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,49 +1,195 @@
-#
-#
-#  Copyright 2016 CUBRID Corporation
-# 
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-# 
-#       http://www.apache.org/licenses/LICENSE-2.0
-# 
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
-# 
-name: github-checks
+name: CUBRID Manual CI/CD (Rocky Linux)
+
 on:
-  - pull_request
+  push:
+    branches: [ "develop", "release/[0-9]*" ]
+  pull_request_target:
+    branches: [ "develop", "release/[0-9]*" ]
 
-# Set environment variables available to all action steps.
-env:
-  DOMAIN: cubrid-manual-${{ github.event.pull_request.number }}.surge.sh
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
+# ---------------------------------------------------------------------------
+# [JOB 1] Parallel Build (en / ko)
+# ---------------------------------------------------------------------------
 jobs:
   build_docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      merged_pr: ${{ steps.pr_info.outputs.merged_pr }}
+      short_sha: ${{ steps.sha.outputs.short_sha }}
     strategy:
       matrix:
         lang: [en, ko]
       fail-fast: false
+    container:
+      image: rockylinux:9.3
     steps:
-    - name: Set up Python
-      uses: actions/checkout@v1
-    - name: Build and Test Sphinx Doc
-      uses: ammaraskar/sphinx-action@7.3.1
-      with:
-        docs-folder: ${{ matrix.lang }}
-        pre-build-command: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-    - name: Check link
-      uses: ammaraskar/sphinx-action@7.3.1
-      with:
-        docs-folder: ${{ matrix.lang }}
-        pre-build-command: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-        build-command: make linkcheck
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Compute short SHA
+        id: sha
+        run: |
+          FULL_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          echo "short_sha=${FULL_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Dependencies (with Retry)
+        run: |
+          # DNF Retry Logic
+          for i in {1..3}; do
+            dnf install -y epel-release && \
+            dnf install -y glibc-locale-source glibc-langpack-ko \
+              gcc make openssl-devel bzip2-devel libffi-devel zlib-devel unzip pango cairo \
+              git gdk-pixbuf2 python3.12 python3.12-pip jq && break || sleep 5;
+          done
+          update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2
+          update-alternatives --set python3 /usr/bin/python3.12
+          # PIP Retry Logic
+          for i in {1..3}; do
+            pip3.12 install 'urllib3<2.0' Sphinx==9.1.0 \
+              sphinx_design sphinxext-rediraffe sphinxawesome-theme==6.0.0 \
+              weasyprint==68.0 sphinx-simplepdf==1.7 sphinx-rtd-theme && break || sleep 5;
+          done
+          localedef -f UTF-8 -i ko_KR ko_KR.utf8
+
+      - name: Build Manual (HTML & PDF)
+        env:
+          LANG: ko_KR.utf8
+        run: |
+          cd ${{ matrix.lang }}
+          make html
+          make pdf
+          if [ -f "_build/simplepdf/CUBRID.pdf" ]; then
+            cp _build/simplepdf/CUBRID.pdf _build/html/CUBRID.pdf
+          fi
+
+      # Save PR number for later jobs (push event only)
+      - name: Get PR number
+        if: github.event_name == 'push'
+        id: pr_info
+        run: |
+          PR_NUMBER=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            | jq -r '.[0].number')
+          echo "merged_pr=${PR_NUMBER:-manual-push}" >> $GITHUB_OUTPUT
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact-${{ matrix.lang }}
+          path: ./${{ matrix.lang }}/_build/html
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # [JOB 2] Sequential Deployment (en → ko, one at a time)
+  # ---------------------------------------------------------------------------
+  deploy_docs:
+    needs: build_docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: gh-pages-deploy-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: false
+    strategy:
+      matrix:
+        lang: [en, ko]
+      max-parallel: 1
+    steps:
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact-${{ matrix.lang }}
+          path: ./dist
+
+      # --- PR Preview Deploy ---
+      - name: Deploy Preview
+        if: github.event_name == 'pull_request_target'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ secrets.GH_PAGES_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist
+          destination_dir: pr-preview/${{ github.event.pull_request.number }}/${{ matrix.lang }}
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
+      # --- Official Deploy (per-commit) ---
+      - name: Set short SHA
+        if: github.event_name == 'push'
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
+
+      - name: Deploy Official (per-commit)
+        if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          personal_token: ${{ secrets.GH_PAGES_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist
+          destination_dir: ${{ matrix.lang }}/${{ github.ref_name }}/${{ env.SHORT_SHA }}
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+
+  # ---------------------------------------------------------------------------
+  # [JOB 3] Post Comments (after all deploys finish)
+  # ---------------------------------------------------------------------------
+  comment_on_pr:
+    needs: [build_docs, deploy_docs]
+    if: success()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # --- Case A: PR Preview Link ---
+      - name: Comment PR Preview Link
+        if: github.event_name == 'pull_request_target'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          github_token: ${{ secrets.GH_PAGES_TOKEN }}
+          pr_number: ${{ github.event.pull_request.number }}
+          message: |
+            ✅ **CUBRID Manual Preview is Ready!**
+
+            All docs (KO/EN) are successfully built and deployed.
+
+            | Type | 🇰🇷 Korean (KO) | 🇺🇸 English (EN) |
+            | :--- | :--- | :--- |
+            | 🌐 **Web** | [View Docs](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/ko/index.html) | [View Docs](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/en/index.html) |
+            | 📄 **PDF** | [Download](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/ko/CUBRID.pdf) | [Download](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/${{ github.event.pull_request.number }}/en/CUBRID.pdf) |
+          comment_tag: cubrid-manual-preview
+          mode: recreate
+
+      # --- Case B: Official Deployment Success (Merge only) ---
+      - name: Comment Official Deploy Success
+        if: github.event_name == 'push' && needs.build_docs.outputs.merged_pr != 'null' && needs.build_docs.outputs.merged_pr != 'manual-push'
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          github_token: ${{ secrets.GH_PAGES_TOKEN }}
+          pr_number: ${{ needs.build_docs.outputs.merged_pr }}
+          message: |
+            🚀 **Official Deployment Complete!** (`${{ needs.build_docs.outputs.short_sha }}`)
+
+            The changes have been merged and published to the official manual.
+
+            | Type | 🇰🇷 Korean (KO) | 🇺🇸 English (EN) |
+            | :--- | :--- | :--- |
+            | 🌐 **Web** | [View Docs](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/ko/${{ github.ref_name }}/${{ needs.build_docs.outputs.short_sha }}/index.html) | [View Docs](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/en/${{ github.ref_name }}/${{ needs.build_docs.outputs.short_sha }}/index.html) |
+            | 📄 **PDF** | [Download](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/ko/${{ github.ref_name }}/${{ needs.build_docs.outputs.short_sha }}/CUBRID.pdf) | [Download](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/en/${{ github.ref_name }}/${{ needs.build_docs.outputs.short_sha }}/CUBRID.pdf) |
+          comment_tag: cubrid-manual-official-deploy
+          mode: create

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -161,7 +161,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         uses: thollander/actions-comment-pull-request@v2
         with:
-          github_token: ${{ secrets.GH_PAGES_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_number: ${{ github.event.pull_request.number }}
           message: |
             ✅ **CUBRID Manual Preview is Ready!**
@@ -180,7 +180,7 @@ jobs:
         if: github.event_name == 'push' && needs.build_docs.outputs.merged_pr != 'null' && needs.build_docs.outputs.merged_pr != 'manual-push'
         uses: thollander/actions-comment-pull-request@v2
         with:
-          github_token: ${{ secrets.GH_PAGES_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_number: ${{ needs.build_docs.outputs.merged_pr }}
           message: |
             🚀 **Official Deployment Complete!** (`${{ needs.build_docs.outputs.short_sha }}`)

--- a/.github/workflows/daily-archive-cleanup.yml
+++ b/.github/workflows/daily-archive-cleanup.yml
@@ -1,0 +1,56 @@
+name: Daily Build Cleanup
+
+on:
+  schedule:
+    # Run at 03:00 KST (18:00 UTC) every day
+    - cron: '0 18 * * *'
+  workflow_dispatch:  # Allows manual execution by administrators
+
+jobs:
+  purge-old-builds:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Delete builds older than 60 days
+        run: |
+          echo "Starting cleanup for builds older than 60 days..."
+
+          # 1. Clean up temporary PR preview folders (pr-preview/*)
+          if [ -d "pr-preview" ]; then
+            find pr-preview/* -maxdepth 0 -type d -mtime +60 -exec rm -rf {} \;
+            echo "Cleaned up old pr-preview folders."
+          fi
+
+          # 2. Clean up per-commit deploy directories ({lang}/{branch}/{short_sha}/)
+          echo "Searching for old per-commit deploy directories..."
+          for lang_dir in en ko; do
+            if [ -d "$lang_dir" ]; then
+              for branch_dir in "$lang_dir"/*/; do
+                if [ -d "$branch_dir" ]; then
+                  find "$branch_dir" -maxdepth 1 -type d -mtime +60 ! -name "$(basename "$branch_dir")" -exec rm -rf {} \;
+                fi
+              done
+            fi
+          done
+
+          # Git configuration for automated commits
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Stage deletion changes
+          git add .
+
+          # Check for changes and push if there is anything to commit
+          if ! git diff --cached --quiet; then
+            git commit -m "Cleanup: Purge archived builds older than 60 days"
+            git push origin gh-pages
+            echo "✅ Successfully pushed cleanup changes."
+          else
+            echo "ℹ️ No old builds found to delete. Everything is clean."
+          fi


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-332

관련해서 이전 PR https://github.com/CUBRID/cubrid-manual/pull/743 은 permission 문제가 발생하는 경우가 있어  revert 했습니다. #744 
리뷰 한번 더 부탁드립니다. 
### **참고! 
**본 PR 에서는 config 에 의해 action 이 동작하지 않습니다. 
원본 repo 브랜치에 머지가 되어 있어야 가능합니다.  (머지 대상 repo 의 config 로 action 이 동작하는 방식)**

**기존**

- en, ko 각각 빌드 성공 여부만 확인

**변경**

- check.yml
PR 브랜치 빌드 결과 생성된 파일(html, pdf) 링크를 PR 화면 해당 commit 다음에 코멘트
머지 완료 후 빌드 및 링크를 PR 화면 하단에 코멘트

- daily-archive-cleanup.yml
60일 이후 결과물 제거

**동작** 

- PR open 시 파일(html, pdf) 링크 정보 comment 됨.
<img width="632" height="600" alt="image" src="https://github.com/user-attachments/assets/70e67e29-db6a-4958-9608-e7609736b2b9" />

- 추가 commit 시 파일(html, pdf) 링크 정보 comment 됨. 이전 comment 는 지워짐.
즉, **최근 commit 에 대한 정보만 comment 표시**. 
<img width="490" height="495" alt="image" src="https://github.com/user-attachments/assets/633b4be1-06fb-44af-9543-28460b3d8a07" />

- 머지하면 해당 브랜치를 빌드하고 생성된 파일(html, pdf) 링크 정보를 PR preview 화면과 비슷하게 PR 화면 하단에 표시. 빌드 및 배포에 동일한 시간 소요. 
<img width="620" height="449" alt="image" src="https://github.com/user-attachments/assets/9775381e-8656-4b54-9f9d-64fed7d4717f" />

- 생성된지 60일 이상된 파일은 한국 시간 새벽 3시에 github action 이 자동 삭제.
