### PR TITLE
[CUBRIDMAN-340] Show Ctrl+k for search shortcut on Windows

### DIFF
--- a/en/_templates/searchbox.html
+++ b/en/_templates/searchbox.html
@@ -1,0 +1,24 @@
+{#- Template for the search box in the header.
+
+Overrides the theme default to make the keyboard shortcut OS-aware:
+- Display ⌘ on macOS, Ctrl on Windows/Linux.
+- Bind Cmd+K (macOS) and Ctrl+K (Windows/Linux). -#}
+<form id="searchbox"
+      x-data="{ isMac: /Mac|iPhone|iPod|iPad/i.test(navigator.platform || navigator.userAgent) }"
+      action="{{ pathto('search') }}"
+      method="get"
+      class="relative flex items-center group"
+      @keydown.k.window.meta="$refs.search.focus()"
+      @keydown.k.window.ctrl.prevent="$refs.search.focus()">
+  <input x-ref="search"
+          name="q"
+          id="search-input"
+          type="search"
+          aria-label="Search the docs"
+          placeholder="{{ _('Search ...') }}"
+          class="inline-flex items-center font-medium transition-colors bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background border border-input hover:bg-accent focus:bg-accent hover:text-accent-foreground focus:text-accent-foreground hover:placeholder-accent-foreground py-2 px-4 relative h-9 w-full justify-start rounded-[0.5rem] text-sm text-muted-foreground sm:pr-12 md:w-40 lg:w-64" />
+  <kbd class="pointer-events-none absolute right-1.5 top-2 hidden h-5 select-none text-muted-foreground items-center gap-1 rounded border border-border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex group-hover:bg-accent group-hover:text-accent-foreground">
+    <span class="text-xs" x-text="isMac ? '⌘' : 'Ctrl'">⌘</span>
+    K
+  </kbd>
+</form>

--- a/en/_templates/searchbox.html
+++ b/en/_templates/searchbox.html
@@ -8,7 +8,7 @@ Overrides the theme default to make the keyboard shortcut OS-aware:
       action="{{ pathto('search') }}"
       method="get"
       class="relative flex items-center group"
-      @keydown.k.window.meta="$refs.search.focus()"
+      @keydown.k.window.meta.prevent="$refs.search.focus()"
       @keydown.k.window.ctrl.prevent="$refs.search.focus()">
   <input x-ref="search"
           name="q"

--- a/ko/_templates/searchbox.html
+++ b/ko/_templates/searchbox.html
@@ -1,0 +1,24 @@
+{#- Template for the search box in the header.
+
+Overrides the theme default to make the keyboard shortcut OS-aware:
+- Display ⌘ on macOS, Ctrl on Windows/Linux.
+- Bind Cmd+K (macOS) and Ctrl+K (Windows/Linux). -#}
+<form id="searchbox"
+      x-data="{ isMac: /Mac|iPhone|iPod|iPad/i.test(navigator.platform || navigator.userAgent) }"
+      action="{{ pathto('search') }}"
+      method="get"
+      class="relative flex items-center group"
+      @keydown.k.window.meta="$refs.search.focus()"
+      @keydown.k.window.ctrl.prevent="$refs.search.focus()">
+  <input x-ref="search"
+          name="q"
+          id="search-input"
+          type="search"
+          aria-label="Search the docs"
+          placeholder="{{ _('Search ...') }}"
+          class="inline-flex items-center font-medium transition-colors bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background border border-input hover:bg-accent focus:bg-accent hover:text-accent-foreground focus:text-accent-foreground hover:placeholder-accent-foreground py-2 px-4 relative h-9 w-full justify-start rounded-[0.5rem] text-sm text-muted-foreground sm:pr-12 md:w-40 lg:w-64" />
+  <kbd class="pointer-events-none absolute right-1.5 top-2 hidden h-5 select-none text-muted-foreground items-center gap-1 rounded border border-border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex group-hover:bg-accent group-hover:text-accent-foreground">
+    <span class="text-xs" x-text="isMac ? '⌘' : 'Ctrl'">⌘</span>
+    K
+  </kbd>
+</form>

--- a/ko/_templates/searchbox.html
+++ b/ko/_templates/searchbox.html
@@ -8,7 +8,7 @@ Overrides the theme default to make the keyboard shortcut OS-aware:
       action="{{ pathto('search') }}"
       method="get"
       class="relative flex items-center group"
-      @keydown.k.window.meta="$refs.search.focus()"
+      @keydown.k.window.meta.prevent="$refs.search.focus()"
       @keydown.k.window.ctrl.prevent="$refs.search.focus()">
   <input x-ref="search"
           name="q"


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBRIDMAN-340

### Purpose
검색창 단축키 안내가 Windows에서도 맥 기준(⌘ k)으로 표시되는 문제를 수정합니다.

### Implementation
- 테마의 `searchbox.html`를 오버라이드

<img width="486" height="54" alt="2026-06-10 103118" src="https://github.com/user-attachments/assets/bb8f9908-20cd-44cb-8a73-86dca86df3c8" />